### PR TITLE
fix: correct function parameter order in update_admin_game

### DIFF
--- a/main.py
+++ b/main.py
@@ -1243,8 +1243,8 @@ async def get_admin_game(
 
 @app.put("/api/admin/games/{game_id}")
 async def update_admin_game(
-    game_id: int = Path(..., description="Game ID"),
     game_data: Dict[str, Any],
+    game_id: int = Path(..., description="Game ID"),
     x_admin_token: Optional[str] = Header(None),
     db: Session = Depends(get_db)
 ):


### PR DESCRIPTION
Fix SyntaxError where non-default argument game_data followed default argument game_id.

This was causing deployment failures on Render.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)