### PR TITLE
Fix React hooks ESLint warning in SortSelect component

### DIFF
--- a/frontend/src/components/public/SortSelect.jsx
+++ b/frontend/src/components/public/SortSelect.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export default function SortSelect({ sort, onChange, className, id, ...props }) {
-  const sortOptions = [
+  const sortOptions = React.useMemo(() => [
     { 
       key: 'title', 
       label: 'Title', 
@@ -26,7 +26,7 @@ export default function SortSelect({ sort, onChange, className, id, ...props }) 
       defaultDir: 'asc',
       description: 'Sort by average playing time (shortest first by default)'
     }
-  ];
+  ], []);
 
   const getCurrentSortKey = React.useCallback(() => {
     // More robust parsing - handle edge cases


### PR DESCRIPTION
Fixes React hooks exhaustive-deps ESLint warning in SortSelect.jsx

Wrapped sortOptions array in useMemo hook to prevent useCallback dependencies from changing on every render.

Generated with [Claude Code](https://claude.ai/code)