### PR TITLE
Fix Mobile Game Card Layout to 2 Columns, Desktop to 4 Columns

### DIFF
--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -429,7 +429,7 @@ export default function PublicCatalogue() {
             {/* Game Results */}
             <section aria-live="polite" id="game-results">
               {loading ? (
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4 mb-6">
+                <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 mb-6">
                   {Array.from({ length: 8 }, (_, i) => (
                     <SkeletonCard key={i} />
                   ))}
@@ -552,7 +552,7 @@ export default function PublicCatalogue() {
                   </div>
 
                   {/* Game Cards Grid with lazy loading */}
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4 mb-6">
+                  <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 mb-6">
                     {items.map((game) => (
                       <div key={game.id} className="transform transition-all duration-300 hover:scale-105 hover:z-50 relative">
                         <GameCardPublic 


### PR DESCRIPTION
Updated game card grid layout to show 2 columns on mobile and 4 columns on desktop, removing the single-column mobile layout that was previously implemented.

## Changes
- Updated PublicCatalogue.jsx grid layout from 1-2-3-4 column responsive to 2-2-4 column layout
- Mobile devices now show 2 game cards side by side instead of single column
- Desktop maintains 4-column layout at large breakpoint (1024px+)
- Simplified responsive breakpoints for better mobile/desktop experience

Fixes #15

Generated with [Claude Code](https://claude.ai/code)