### PR TITLE
Fix Mobile Game Card Responsiveness and Desktop Background

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -123,7 +123,7 @@ export default function GameCardPublic({ game, lazy = false, onShare }) {
           </h3>
           
           {/* Game Info Grid */}
-          <div className="grid grid-cols-2 gap-2 sm:gap-3 mb-3 sm:mb-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-3 mb-3 sm:mb-4">
             {/* Players */}
             <div className="flex items-center gap-2">
               <div className="w-7 h-7 sm:w-8 sm:h-8 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,7 +9,7 @@ html, body, #root {
 }
 
 body {
-  background: #f4f1e8;
+  background: linear-gradient(to bottom right, #fef7dc, #d6f5d6, #ccf2f4);
   color: #1f2f2d;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
Fix mobile game card responsiveness and desktop background

- GameCardPublic.jsx: Changed internal grid from grid-cols-2 to grid-cols-1 sm:grid-cols-2
  This makes game info stack vertically on mobile for better readability
  while maintaining 2-column layout on desktop
- index.css: Updated body background from brown (#f4f1e8) to gradient
  matching the theme used in PublicCatalogue.jsx

Mobile cards now show 2 cards side-by-side with readable single-column
info layout. Desktop brown boxes are eliminated.

Fixes #15

Generated with [Claude Code](https://claude.ai/code)