### PR TITLE
Fix edit category 405 error by adding POST alternative endpoint

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -113,7 +113,7 @@ export const imageProxyUrl = (rawUrl) =>
   `${API_BASE}/api/public/image-proxy?url=${encodeURIComponent(rawUrl)}`;
 
 export async function updateGame(gameId, patch) {
-  const r = await api.put(`/api/admin/games/${gameId}`, patch, { headers: getAdminHeaders() });
+  const r = await api.post(`/api/admin/games/${gameId}/update`, patch, { headers: getAdminHeaders() });
   return r.data;
 }
 

--- a/main.py
+++ b/main.py
@@ -1410,6 +1410,54 @@ async def update_admin_game(
         raise HTTPException(status_code=500, detail="Failed to update game")
 
 
+@app.post("/api/admin/games/{game_id}/update")
+async def update_admin_game_post(
+    game_data: Dict[str, Any],
+    request: Request,
+    game_id: int = Path(..., description="Game ID"),
+    x_admin_token: Optional[str] = Header(None),
+    db: Session = Depends(get_db)
+):
+    """Update game via POST (admin only) - alternative to PUT for proxy compatibility"""
+    _require_admin_token(x_admin_token, _get_client_ip(request))
+
+    game = db.execute(select(Game).where(Game.id == game_id)).scalar_one_or_none()
+    if not game:
+        raise GameNotFoundError(f"Game {game_id} not found")
+
+    try:
+        # Update allowed fields
+        if "title" in game_data:
+            game.title = game_data["title"]
+        if "year" in game_data:
+            game.year = game_data["year"]
+        if "description" in game_data and hasattr(game, 'description'):
+            game.description = game_data["description"]
+        if "mana_meeple_category" in game_data:
+            game.mana_meeple_category = game_data["mana_meeple_category"]
+        if "players_min" in game_data:
+            game.players_min = game_data["players_min"]
+        if "players_max" in game_data:
+            game.players_max = game_data["players_max"]
+        if "playtime_min" in game_data:
+            game.playtime_min = game_data["playtime_min"]
+        if "playtime_max" in game_data:
+            game.playtime_max = game_data["playtime_max"]
+        if "min_age" in game_data and hasattr(game, 'min_age'):
+            game.min_age = game_data["min_age"]
+
+        db.commit()
+        db.refresh(game)
+
+        logger.info(f"Updated game via POST: {game.title} (ID: {game.id})", extra={'game_id': game.id})
+        return _game_to_dict(None, game)
+
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Failed to update game {game_id} via POST: {e}", extra={'game_id': game_id})
+        raise HTTPException(status_code=500, detail="Failed to update game")
+
+
 @app.delete("/api/admin/games/{game_id}")
 async def delete_admin_game(
     request: Request,
@@ -1419,19 +1467,19 @@ async def delete_admin_game(
 ):
     """Delete game (admin only)"""
     _require_admin_token(x_admin_token, _get_client_ip(request))
-    
+
     game = db.execute(select(Game).where(Game.id == game_id)).scalar_one_or_none()
     if not game:
         raise GameNotFoundError(f"Game {game_id} not found")
-    
+
     try:
         game_title = game.title
         db.delete(game)
         db.commit()
-        
+
         logger.info(f"Deleted game: {game_title} (ID: {game_id})", extra={'game_id': game_id})
         return {"message": f"Game '{game_title}' deleted successfully"}
-        
+
     except Exception as e:
         db.rollback()
         logger.error(f"Failed to delete game {game_id}: {e}", extra={'game_id': game_id})


### PR DESCRIPTION
The issue was that the PHP proxy at https://manaandmeeples.co.nz/library/api-proxy.php doesn't properly support PUT requests, returning 405 Method Not Allowed errors.

Changes:
- Added POST /api/admin/games/{game_id}/update endpoint as alternative to PUT
- Updated frontend updateGame() to use POST instead of PUT
- Maintains all existing functionality while working around proxy limitations

Fixes #31

Generated with [Claude Code](https://claude.ai/code)