### PR TITLE
fix: allow PUT and DELETE methods in api-proxy.php

### DIFF
--- a/frontend/public/api-proxy.php
+++ b/frontend/public/api-proxy.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 $UPSTREAM = 'https://mana-meeples-boardgame-list.onrender.com';
-$ALLOWED_METHODS = ['GET', 'POST'];
+$ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
 
 // Enable error reporting for debugging
 error_reporting(E_ALL);
@@ -10,7 +10,7 @@ ini_set('display_errors', 1);
 
 // Add CORS headers
 header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Admin-Token');
 
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {


### PR DESCRIPTION
Fixes 405 method_not_allowed error when editing categories.

The proxy was only allowing GET and POST methods, but the admin interface uses PUT requests to update game data.

Changes:
- Added PUT and DELETE to ALLOWED_METHODS array
- Updated CORS headers to include PUT and DELETE methods

Fixes #39

Generated with [Claude Code](https://claude.ai/code)