### PR TITLE
fix: NZ designer filter not working properly

### DIFF
--- a/main.py
+++ b/main.py
@@ -808,9 +808,11 @@ async def get_public_games(
         if hasattr(Game, 'designers'):
             query = query.where(Game.designers.ilike(designer_filter))
 
-    #Apply NZ designer filter
+    # Apply NZ designer filter
     if nz_designer is not None:
-        query = query.where(Game.nz_designer == nz_designer)
+        # Convert string parameter to boolean for database comparison
+        nz_designer_bool = nz_designer.lower() in ['true', '1', 'yes'] if isinstance(nz_designer, str) else bool(nz_designer)
+        query = query.where(Game.nz_designer == nz_designer_bool)
     
     # Apply sorting
     if sort == "title_desc":


### PR DESCRIPTION
Fixes the NZ designer button that wasn't showing games despite database having games marked as nz_designer=True.

The issue was a data type mismatch where string parameters were being compared directly to boolean database fields.

Fixes #43

Generated with [Claude Code](https://claude.ai/code)