### PR TITLE
Remove persistent disk dependency from thumbs.py

### DIFF
--- a/thumbs.py
+++ b/thumbs.py
@@ -2,7 +2,8 @@ import os, re, httpx
 from typing import Optional
 from config import HTTP_TIMEOUT
 
-THUMBS_DIR = "/data/thumbs"
+# Use /tmp for Render free tier compatibility (ephemeral storage)
+THUMBS_DIR = os.getenv("THUMBS_DIR", "/tmp/thumbs")
 
 # File validation constants
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB


### PR DESCRIPTION
Changed THUMBS_DIR from hardcoded /data/thumbs to environment variable with /tmp/thumbs default, matching main.py configuration.

This ensures all thumbnail operations use ephemeral storage and won't fail with permission errors on Render free tier.