### PR TITLE
Reactivate disk on live render instance

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,3 +18,9 @@ services:
         value: https://manaandmeeples.co.nz,https://www.manaandmeeples.co.nz
       - key: PUBLIC_BASE_URL
         value: https://mana-meeples-boardgame-list.onrender.com
+      - key: THUMBS_DIR
+        value: /var/data/thumbs
+    disks:
+      - name: thumbs-storage
+        mountPath: /var/data
+        sizeGB: 1


### PR DESCRIPTION
Changes:
- Add THUMBS_DIR environment variable pointing to /var/data/thumbs
- Configure 1GB persistent disk mounted at /var/data
- Thumbs.py will automatically use the persistent path via environment variable

This restores persistent thumbnail caching while maintaining the existing fallback to /tmp for local development.