### PR TITLE
Fix deprecated mobile web app meta tag

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -32,7 +32,7 @@
     <!-- Additional SEO -->
     <meta name="application-name" content="Mana & Meeples Library" />
     <meta name="apple-mobile-web-app-title" content="Mana & Meeples" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     
     <title>Mana & Meeples Library</title>

--- a/main.py
+++ b/main.py
@@ -295,6 +295,8 @@ app.add_middleware(CacheThumbsMiddleware)
 cors_origins = [
     "https://manaandmeeples.co.nz",
     "https://www.manaandmeeples.co.nz",
+    "https://library.manaandmeeples.co.nz",
+    "https://mana-meeples-library-web.onrender.com",
     "http://localhost:3000",
     "http://127.0.0.1:3000"
 ]


### PR DESCRIPTION
- Replace deprecated apple-mobile-web-app-capable with mobile-web-app-capable meta tag
- Add missing CORS origins for library.manaandmeeples.co.nz and mana-meeples-library-web.onrender.com
- Resolves browser console warnings about deprecated meta tag
- Fixes CORS policy blocking API requests from frontend domain