### PR TITLE
Refactor sort function into dropdown menu

### DIFF
--- a/frontend/src/components/public/SortSelect.jsx
+++ b/frontend/src/components/public/SortSelect.jsx
@@ -70,64 +70,82 @@ export default function SortSelect({ sort, onChange, className, id, ...props }) 
     });
   }, [sort, getCurrentSortKey, getCurrentDirection]);
 
+  const handleFieldChange = (e) => {
+    const newKey = e.target.value;
+    const option = sortOptions.find(opt => opt.key === newKey);
+    const newSort = `${newKey}_${option.defaultDir}`;
+    console.log(`Changing sort field: ${sort} → ${newSort}`);
+    onChange(newSort);
+  };
+
+  const handleDirectionToggle = () => {
+    const currentKey = getCurrentSortKey();
+    const currentDir = getCurrentDirection();
+    const newDir = currentDir === 'asc' ? 'desc' : 'asc';
+    const newSort = `${currentKey}_${newDir}`;
+    console.log(`Toggling sort direction: ${sort} → ${newSort}`);
+    onChange(newSort);
+  };
+
+  const currentKey = getCurrentSortKey();
+  const currentDir = getCurrentDirection();
+  const directionIcon = currentDir === 'desc' ? '↓' : '↑';
+  const directionText = currentDir === 'desc' ? 'descending' : 'ascending';
+
   return (
     <div className="w-full">
       {/* Screen reader label */}
       <span className="sr-only">Choose how to sort games</span>
-      
-      {/* Grid layout for sort buttons */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        {sortOptions.map(option => {
-          const isActive = getCurrentSortKey() === option.key;
-          const direction = isActive ? getCurrentDirection() : option.defaultDir;
-          const directionIcon = direction === 'desc' ? '↓' : '↑';
-          const directionText = direction === 'desc' ? 'descending' : 'ascending';
-          
-          return (
-            <button
-              key={option.key}
-              onClick={() => handleSortClick(option.key)}
-              className={`
-                group relative px-3 py-2.5 text-sm font-medium rounded-lg border-2 
-                transition-all duration-200 min-h-[44px]
-                focus:outline-none focus:ring-3 focus:ring-offset-2
-                ${isActive 
-                  ? 'bg-emerald-500 text-white border-emerald-500 shadow-lg focus:ring-emerald-300 transform scale-105' 
-                  : 'bg-white text-slate-700 border-slate-300 hover:bg-emerald-50 hover:border-emerald-300 focus:ring-emerald-300 hover:shadow-md'
-                }
-              `}
-              title={`${option.description}. Currently ${directionText}. Click to ${isActive ? 'toggle direction' : 'select this sort option'}.`}
-              aria-pressed={isActive}
-              aria-describedby={`sort-${option.key}-help`}
-            >
-              <span className="flex items-center justify-center gap-1.5">
-                <span>{option.label}</span>
-                <span 
-                  className={`text-sm transition-transform duration-200 ${
-                    isActive ? 'scale-110' : 'opacity-75'
-                  }`}
-                  aria-hidden="true"
-                >
-                  {directionIcon}
-                </span>
-              </span>
-              
-              {/* Hidden help text for screen readers */}
-              <span id={`sort-${option.key}-help`} className="sr-only">
-                {option.description}. Current direction: {directionText}.
-              </span>
-            </button>
-          );
-        })}
+
+      {/* Dropdown + Direction Button Layout */}
+      <div className="flex gap-2">
+        {/* Dropdown for sort field */}
+        <select
+          value={currentKey}
+          onChange={handleFieldChange}
+          className="
+            flex-1 px-3 py-2.5 text-sm font-medium rounded-lg border-2 border-slate-300
+            bg-white text-slate-700
+            hover:border-emerald-300 hover:bg-emerald-50
+            focus:outline-none focus:ring-3 focus:ring-emerald-300 focus:ring-offset-2 focus:border-emerald-500
+            transition-all duration-200 min-h-[44px] cursor-pointer
+          "
+          aria-label="Choose sort field"
+        >
+          {sortOptions.map(option => (
+            <option key={option.key} value={option.key}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Direction toggle button */}
+        <button
+          onClick={handleDirectionToggle}
+          className="
+            px-4 py-2.5 text-sm font-medium rounded-lg border-2
+            bg-emerald-500 text-white border-emerald-500 shadow-lg
+            hover:bg-emerald-600 hover:border-emerald-600
+            focus:outline-none focus:ring-3 focus:ring-emerald-300 focus:ring-offset-2
+            transition-all duration-200 min-h-[44px] min-w-[44px]
+            flex items-center justify-center
+          "
+          title={`Currently sorting ${directionText}. Click to toggle direction.`}
+          aria-label={`Toggle sort direction. Currently ${directionText}`}
+        >
+          <span className="text-lg" aria-hidden="true">
+            {directionIcon}
+          </span>
+        </button>
       </div>
-      
+
       {/* Debug info - remove in production */}
       {process.env.NODE_ENV === 'development' && (
         <div className="mt-2 p-2 bg-gray-100 rounded text-xs text-gray-600">
           <strong>Debug:</strong> sort="{sort}", key="{getCurrentSortKey()}", dir="{getCurrentDirection()}"
         </div>
       )}
-      
+
       {/* Current sort status for screen readers */}
       <div className="sr-only" aria-live="polite" role="status">
         Currently sorting by {getCurrentSortKey()} in {getCurrentDirection() === 'desc' ? 'descending' : 'ascending'} order

--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -386,86 +386,19 @@ useEffect(() => {
                     </div>
                   )}
                 </div>
-                
-                {/* Row 2: First 2 Sort Buttons */}
-                <div className="grid grid-cols-2 gap-3">
-                  <button
-                    onClick={() => updateSort('title_asc')}
-                    className={`
-                      min-h-[48px] px-3 py-2.5 text-sm font-medium rounded-xl 
-                      transition-all duration-200 focus:outline-none focus:ring-3 focus:ring-offset-2
-                      ${sort.startsWith('title') 
-                        ? "bg-emerald-600 text-white shadow-lg focus:ring-emerald-300" 
-                        : "bg-white text-slate-700 border-2 border-slate-300 hover:bg-emerald-50 hover:border-emerald-300 focus:ring-emerald-300"
-                      }
-                    `}
-                    aria-pressed={sort.startsWith('title')}
-                  >
-                    <span className="flex items-center justify-center gap-1.5">
-                      <span>Title</span>
-                      <span aria-hidden="true">{sort === 'title_desc' ? '↓' : '↑'}</span>
-                    </span>
-                  </button>
-                  
-                  <button
-                    onClick={() => updateSort('year_desc')}
-                    className={`
-                      min-h-[48px] px-3 py-2.5 text-sm font-medium rounded-xl 
-                      transition-all duration-200 focus:outline-none focus:ring-3 focus:ring-offset-2
-                      ${sort.startsWith('year') 
-                        ? "bg-emerald-600 text-white shadow-lg focus:ring-emerald-300" 
-                        : "bg-white text-slate-700 border-2 border-slate-300 hover:bg-emerald-50 hover:border-emerald-300 focus:ring-emerald-300"
-                      }
-                    `}
-                    aria-pressed={sort.startsWith('year')}
-                  >
-                    <span className="flex items-center justify-center gap-1.5">
-                      <span>Year</span>
-                      <span aria-hidden="true">{sort === 'year_asc' ? '↑' : '↓'}</span>
-                    </span>
-                  </button>
+
+                {/* Row 2: Sort Dropdown + Direction Button */}
+                <div>
+                  <label className="block text-sm font-semibold text-slate-700 mb-1.5">
+                    Sort By
+                  </label>
+                  <SortSelect
+                    sort={sort}
+                    onChange={updateSort}
+                  />
                 </div>
-                
-                {/* Row 3: Second 2 Sort Buttons */}
-                <div className="grid grid-cols-2 gap-3">
-                  <button
-                    onClick={() => updateSort('rating_desc')}
-                    className={`
-                      min-h-[48px] px-3 py-2.5 text-sm font-medium rounded-xl 
-                      transition-all duration-200 focus:outline-none focus:ring-3 focus:ring-offset-2
-                      ${sort.startsWith('rating') 
-                        ? "bg-emerald-600 text-white shadow-lg focus:ring-emerald-300" 
-                        : "bg-white text-slate-700 border-2 border-slate-300 hover:bg-emerald-50 hover:border-emerald-300 focus:ring-emerald-300"
-                      }
-                    `}
-                    aria-pressed={sort.startsWith('rating')}
-                  >
-                    <span className="flex items-center justify-center gap-1.5">
-                      <span>Rating</span>
-                      <span aria-hidden="true">{sort === 'rating_asc' ? '↑' : '↓'}</span>
-                    </span>
-                  </button>
-                  
-                  <button
-                    onClick={() => updateSort('time_asc')}
-                    className={`
-                      min-h-[48px] px-3 py-2.5 text-sm font-medium rounded-xl 
-                      transition-all duration-200 focus:outline-none focus:ring-3 focus:ring-offset-2
-                      ${sort.startsWith('time') 
-                        ? "bg-emerald-600 text-white shadow-lg focus:ring-emerald-300" 
-                        : "bg-white text-slate-700 border-2 border-slate-300 hover:bg-emerald-50 hover:border-emerald-300 focus:ring-emerald-300"
-                      }
-                    `}
-                    aria-pressed={sort.startsWith('time')}
-                  >
-                    <span className="flex items-center justify-center gap-1.5">
-                      <span>Time</span>
-                      <span aria-hidden="true">{sort === 'time_desc' ? '↓' : '↑'}</span>
-                    </span>
-                  </button>
-                </div>
-                
-                {/* Row 4: Quick Action Buttons and NZ Designer Filter */}
+
+                {/* Row 3: Quick Action Buttons and NZ Designer Filter */}
                 <div className="grid grid-cols-3 gap-3">
                   <button
                     onClick={showNewestGames}


### PR DESCRIPTION
Changed the sort functionality from 4 separate buttons to a more compact design:
- Dropdown menu for selecting sort field (Title, Year, Rating, Time)
- Separate up/down button to toggle sort direction (ascending/descending)
- Applied to both desktop and mobile layouts for consistency
- Maintains accessibility with ARIA labels and keyboard navigation

This design takes up significantly less space while providing the same functionality.