### PR TITLE
Fix: Use proper API client for BGG imports instead of raw fetch

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -203,3 +203,12 @@ export async function validateAdminToken() {
   const r = await api.get("/api/admin/validate", { headers: getAdminHeaders() });
   return r.data;
 }
+
+// Import game from BoardGameGeek by BGG ID
+export async function importFromBGG(bggId, force = false) {
+  const r = await api.post("/api/admin/import/bgg", null, {
+    params: { bgg_id: bggId, force },
+    headers: getAdminHeaders()
+  });
+  return r.data;
+}


### PR DESCRIPTION
ROOT CAUSE: The addGameByBggId function was using raw fetch with an incorrect API base URL fallback ('/library/api-proxy.php?path=') instead of the properly configured API base URL.

CHANGES:
- Added importFromBGG() function to api/client.js
- Updated App.js to use importFromBGG() from API client
- Removed raw fetch call with incorrect URL
- API client uses correct base URL resolution:
  1. window.__API_BASE__
  2. meta tag
  3. REACT_APP_API_BASE env var
  4. Production default: https://mana-meeples-boardgame-list.onrender.com

BENEFITS:
- Fixes persistent network errors when adding games via BGG ID
- Uses axios interceptors for better error handling
- Maintains retry logic with exponential backoff
- Consistent API configuration across all endpoints