### PR TITLE
Fix frontend build error - remove duplicate validateAdminToken declar…

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -321,11 +321,6 @@ export async function getDbHealthCheck() {
  */
 export const imageProxyUrl = proxyUrl;
 
-export async function validateAdminToken() {
-  const r = await api.get("/api/admin/validate", { headers: getAdminHeaders() });
-  return r.data;
-}
-
 // Import game from BoardGameGeek by BGG ID
 export async function importFromBGG(bggId, force = false) {
   const r = await api.post("/api/admin/import/bgg", null, {


### PR DESCRIPTION
…ation

The validateAdminToken function was declared twice in client.js (lines 245 and 324), causing a syntax error during build. Removed the duplicate declaration while preserving the original function definition.