### PR TITLE
Fix production API base URL: Change REACT_APP_API_BASE to VITE_API_BA…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -29,7 +29,7 @@ services:
     buildCommand: cd frontend && npm install && npm run build
     staticPublishPath: ./frontend/build
     envVars:
-      - key: REACT_APP_API_BASE
+      - key: VITE_API_BASE
         value: https://mana-meeples-boardgame-list-opgf.onrender.com
     routes:
       - type: rewrite


### PR DESCRIPTION
…SE for Vite migration

After migrating from Create React App to Vite, the environment variable prefix changed from REACT_APP_ to VITE_. This was causing the frontend to fallback to localhost (127.0.0.1:8000) in production instead of connecting to the actual backend API.

This fixes the ERR_CONNECTION_REFUSED error on the admin login page in production.