### PR TITLE
Fix authentication to use cookie-based sessions instead of localStorage

### DIFF
--- a/frontend/src/context/StaffContext.jsx
+++ b/frontend/src/context/StaffContext.jsx
@@ -71,22 +71,16 @@ export function StaffProvider({ children }) {
   }, []);
 
   /**
-   * Validate admin token on mount
+   * Validate admin session on mount (cookie-based authentication)
    */
   useEffect(() => {
     const validateToken = async () => {
-      const t = localStorage.getItem('ADMIN_TOKEN');
-      if (!t) {
-        navigate('/staff/login');
-        return;
-      }
-
       try {
+        // Validate the session cookie (no localStorage needed for cookie-based auth)
         await validateAdminToken();
         setIsValidating(false);
       } catch (error) {
-        // Token is invalid, clear it and redirect to login
-        localStorage.removeItem('ADMIN_TOKEN');
+        // Session is invalid or expired, redirect to login
         navigate('/staff/login');
       }
     };

--- a/frontend/src/pages/StaffView.jsx
+++ b/frontend/src/pages/StaffView.jsx
@@ -5,6 +5,9 @@ import { useNavigate } from "react-router-dom";
 // ---- Context ----
 import { StaffProvider, useStaff } from "../context/StaffContext";
 
+// ---- API ----
+import { adminLogout } from "../api/client";
+
 // ---- UI components ----
 import CategoryFilter from "../components/CategoryFilter";
 import CategorySelectModal from "../components/CategorySelectModal";
@@ -49,10 +52,17 @@ function StaffViewContent() {
     showToast,
   } = useStaff();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (window.confirm("Are you sure you want to logout?")) {
-      localStorage.removeItem("ADMIN_TOKEN");
-      navigate("/staff/login");
+      try {
+        // Call logout endpoint to clear session cookie
+        await adminLogout();
+      } catch (error) {
+        console.error("Logout error:", error);
+      } finally {
+        // Always navigate to login, even if logout API fails
+        navigate("/staff/login");
+      }
     }
   };
 


### PR DESCRIPTION
The login endpoint was updated to use secure httpOnly cookies, but the StaffView was still checking for localStorage tokens. This caused an infinite redirect loop:
1. Login succeeds and sets cookie
2. Navigate to /staff
3. StaffContext checks localStorage (not cookies)
4. No token found, redirect back to login

Changes:
- StaffContext: Remove localStorage check, use cookie-based validateAdminToken() API
- StaffView: Update logout to call adminLogout() API to clear server-side session
- Remove all localStorage.getItem('ADMIN_TOKEN') checks
- Proper cookie-based authentication flow throughout

This completes the migration from insecure localStorage to secure httpOnly cookies.