### PR TITLE
Fix mobile scroll jump on game cards

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -28,7 +28,7 @@ export default function GameCardPublic({
           if (cardRef.current) {
             cardRef.current.scrollIntoView({
               behavior: prefersReducedMotion ? 'auto' : 'smooth',
-              block: 'start'
+              block: 'nearest'
             });
           }
         }, 100);
@@ -80,7 +80,7 @@ export default function GameCardPublic({
   return (
     <article
       ref={cardRef}
-      className={`group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 ${isExpanded ? 'col-span-2 sm:col-span-1' : ''}`}
+      className={`scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 ${isExpanded ? 'col-span-2 sm:col-span-1' : ''}`}
     >
 
       {/* Image Section - Always Visible */}

--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -288,15 +288,16 @@ export default function PublicCatalogue() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-emerald-50 to-amber-50">
       <div className="container mx-auto px-4 py-4 sm:py-8">
         
-        {/* Header - with scroll-away behavior */}
-        <header
-          ref={headerRef}
-          className={`text-center ${transitionClass} ${
-            isHeaderVisible
-              ? 'opacity-100 translate-y-0 mb-4'
-              : 'opacity-0 -translate-y-full pointer-events-none h-0 mb-0 overflow-hidden'
-          }`}
-        >
+        {/* Header - with scroll-away behavior - wrapped to prevent layout shift */}
+        <div className="mb-4">
+          <header
+            ref={headerRef}
+            className={`text-center ${transitionClass} ${
+              isHeaderVisible
+                ? 'opacity-100 translate-y-0'
+                : 'opacity-0 -translate-y-full pointer-events-none h-0 overflow-hidden'
+            }`}
+          >
           <h1 className="text-2xl sm:text-4xl font-bold bg-gradient-to-r from-emerald-700 via-teal-600 to-amber-600 bg-clip-text text-transparent mb-2">
             Mana & Meeples
           </h1>
@@ -349,6 +350,7 @@ export default function PublicCatalogue() {
             </div>
           </section>
         </header>
+        </div>
 
         <main id="main-content">
 


### PR DESCRIPTION
- Wrap header in fixed-margin container to prevent layout shift when header hides
- Add scroll-mt-24 to game cards to account for sticky toolbar height
- Change scrollIntoView block from 'start' to 'nearest' for smoother behavior
- Fixes issue where scrolling down caused cards to jump when hitting top of screen
- Fixes issue where expanded card images appeared behind sticky filter bar