### PR TITLE
fix: Add database sequence reset endpoint to resolve duplicate key er…

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -218,6 +218,16 @@ export async function reimportAllGames() {
   return r.data;
 }
 
+/**
+ * Fix PostgreSQL sequence for boardgames table
+ * Resolves "duplicate key value violates unique constraint" errors
+ * @returns {Promise<Object>} Sequence fix result with max_id and next_id
+ */
+export async function fixDatabaseSequence() {
+  const r = await api.post("/api/admin/fix-sequence", {});
+  return r.data;
+}
+
 // ============================================================================
 // ADMIN API METHODS - Authentication
 // ============================================================================


### PR DESCRIPTION
…rors

Add admin endpoint and UI button to fix PostgreSQL sequence issues that cause "duplicate key value violates unique constraint" errors when importing games.

Backend changes:
- Add POST /api/admin/fix-sequence endpoint to reset boardgames_id_seq
- Uses SQLAlchemy text() for safe SQL execution
- Returns max_id and next_id for verification

Frontend changes:
- Add fixDatabaseSequence() API client function
- Add "Fix Database Sequence" button to Admin Tools panel
- Display confirmation and success messages

This resolves the issue where auto-increment IDs conflict with existing records after database migrations or bulk imports.