### PR TITLE
refactor: Convert Manage Library to compact table view and fix stats

### DIFF
--- a/frontend/src/components/staff/tabs/DashboardTab.jsx
+++ b/frontend/src/components/staff/tabs/DashboardTab.jsx
@@ -68,17 +68,13 @@ export function DashboardTab({ onTabChange }) {
       </div>
 
       {/* Quick Stats */}
-      <div className="grid md:grid-cols-4 gap-4">
+      <div className="grid md:grid-cols-3 gap-4">
         <div className="bg-white rounded-lg p-5 shadow">
           <div className="text-sm text-gray-600 mb-1">Total Games</div>
           <div className="text-3xl font-bold text-purple-700">{stats.total}</div>
         </div>
         <div className="bg-white rounded-lg p-5 shadow">
-          <div className="text-sm text-gray-600 mb-1">Available</div>
-          <div className="text-3xl font-bold text-green-700">{stats.available}</div>
-        </div>
-        <div className="bg-white rounded-lg p-5 shadow">
-          <div className="text-sm text-gray-600 mb-1">Average Rating</div>
+          <div className="text-sm text-gray-600 mb-1">Average BGG Rating</div>
           <div className="text-3xl font-bold text-blue-700">{stats.avgRating}</div>
         </div>
         <div className="bg-white rounded-lg p-5 shadow">

--- a/frontend/src/context/StaffContext.jsx
+++ b/frontend/src/context/StaffContext.jsx
@@ -122,13 +122,12 @@ export function StaffProvider({ children }) {
    */
   const stats = useMemo(() => {
     const total = library.length;
-    const available = library.filter((g) => g.available).length;
-    const rated = library.filter((g) => typeof g.rating === 'number');
+    const rated = library.filter((g) => typeof g.average_rating === 'number' && g.average_rating > 0);
     const avg =
       rated.length > 0
-        ? (rated.reduce((s, g) => s + g.rating, 0) / rated.length).toFixed(1)
+        ? (rated.reduce((s, g) => s + g.average_rating, 0) / rated.length).toFixed(1)
         : 'N/A';
-    return { total, available, avgRating: avg };
+    return { total, avgRating: avg };
   }, [library]);
 
   /**

--- a/frontend/src/pages/StaffView.jsx
+++ b/frontend/src/pages/StaffView.jsx
@@ -114,8 +114,7 @@ function StaffViewContent() {
           <div className="flex items-center gap-4">
             <div className="text-sm text-gray-600 hidden md:block">
               <span className="font-semibold">{stats.total}</span> games ·{" "}
-              <span className="font-semibold">{stats.available}</span> available ·{" "}
-              <span className="font-semibold">{stats.avgRating}</span> avg rating
+              <span className="font-semibold">{stats.avgRating}</span> avg BGG rating
             </div>
             <button
               onClick={handleLogout}


### PR DESCRIPTION
Changes:
- Manage Library now uses a clean table format with columns:
  - Thumbnail (48x48 with fallback)
  - Name (with year)
  - BGG ID (clickable link)
  - Category (badge)
  - Actions (Edit Category & Delete buttons)
- Removed pagination (shows all games in filtered view)
- Enhanced search to include BGG ID filtering
- Fixed average rating calculation (was using wrong field name)
- Removed "Available" stat (not meaningful)
- Updated Dashboard to show 3 stats instead of 4
- Updated header stats display

Technical fixes:
- Changed stats calculation to use `average_rating` field instead of `rating`
- Imported imageProxyUrl from correct path (api/client)
- Improved table responsiveness with overflow-x-auto
- Added hover states and proper spacing for table rows