### PR TITLE
feat: Add status column and BGG ID import for buy list

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -51,6 +51,8 @@ class Game(Base):
     is_cooperative = Column(Boolean, nullable=True)
     nz_designer = Column(Boolean, nullable=True, default=False, index=True)
     game_type = Column(String(255), nullable=True, index=True)
+    # Ownership status: OWNED (in physical collection), BUY_LIST (want to buy), WISHLIST (maybe buy)
+    status = Column(String(20), nullable=True, default="OWNED", index=True)
 
     # Performance indexes for common queries
     __table_args__ = (

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -71,13 +71,19 @@ class AdminLogin(BaseModel):
 
 
 class BuyListGameCreate(BaseModel):
-    """Schema for adding a game to the buy list"""
+    """Schema for adding a game to the buy list by BGG ID"""
 
-    game_id: int
+    bgg_id: int
     rank: Optional[int] = None
     bgo_link: Optional[str] = None
     lpg_rrp: Optional[float] = None
     lpg_status: Optional[str] = None
+
+    @validator("bgg_id")
+    def validate_bgg_id(cls, v):
+        if v <= 0 or v > 999999:
+            raise ValueError("BGG ID must be between 1 and 999999")
+        return v
 
 
 class BuyListGameUpdate(BaseModel):


### PR DESCRIPTION
- Add 'status' column to boardgames (OWNED, BUY_LIST, WISHLIST)
- Update buy list to accept BGG ID instead of existing game
- Auto-import games from BGG when adding by BGG ID
- Update frontend modal to use BGG ID input
- Removes need to have game in library before adding to buy list
- Games not yet purchased are marked with status='BUY_LIST'