### PR TITLE
fix: Add write permissions to GitHub Actions workflow for pushing pri…

### DIFF
--- a/.github/workflows/fetch-buy-list-prices.yml
+++ b/.github/workflows/fetch-buy-list-prices.yml
@@ -15,6 +15,10 @@ on:
       - 'backend/scripts/export_buy_list.py'
       - '.github/workflows/fetch-buy-list-prices.yml'
 
+# Grant write permissions to the workflow
+permissions:
+  contents: write
+
 jobs:
   fetch-prices:
     runs-on: ubuntu-latest
@@ -81,6 +85,8 @@ jobs:
           fi
 
       - name: Commit and push price data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -92,7 +98,8 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "chore: Update buy list prices [skip ci]"
-            git push
+            # Use GITHUB_TOKEN for authentication
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:${{ github.ref }}
           fi
 
       - name: Upload price data as artifact


### PR DESCRIPTION
…ce data

- Add 'permissions: contents: write' to workflow
- Use GITHUB_TOKEN for authenticated git push
- Fixes 403 error when trying to commit price updates