### PR TITLE
feat: Add complete price tracking with Low, Mean, Disc-mean, and Delta

### DIFF
--- a/backend/api/routers/buy_list.py
+++ b/backend/api/routers/buy_list.py
@@ -116,6 +116,9 @@ def build_buy_list_response(
             "discount_pct": (
                 float(latest_price.discount_pct) if latest_price.discount_pct else None
             ),
+            "disc_mean_pct": (
+                float(latest_price.disc_mean_pct) if latest_price.disc_mean_pct else None
+            ),
             "delta": float(latest_price.delta) if latest_price.delta else None,
         }
 
@@ -685,6 +688,7 @@ async def import_prices_from_json(
                     best_price=game_data.get("best_price"),
                     best_store=game_data.get("best_store"),
                     discount_pct=game_data.get("discount_pct"),
+                    disc_mean_pct=game_data.get("disc_mean_pct"),
                     delta=game_data.get("delta"),
                     source_file=source_file,
                 )

--- a/backend/database.py
+++ b/backend/database.py
@@ -335,6 +335,31 @@ def run_migrations():
                 conn.commit()
                 logger.info("price_offers table created successfully")
 
+            # Migration 5: Add disc_mean_pct column to price_snapshots
+            result = conn.execute(
+                text(
+                    """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name='price_snapshots' AND column_name='disc_mean_pct'
+            """
+                )
+            )
+            column_exists = result.fetchone() is not None
+
+            if not column_exists:
+                logger.info("Adding disc_mean_pct column to price_snapshots table...")
+                conn.execute(
+                    text(
+                        """
+                    ALTER TABLE price_snapshots
+                    ADD COLUMN disc_mean_pct NUMERIC(5, 2)
+                """
+                    )
+                )
+                conn.commit()
+                logger.info("disc_mean_pct column added successfully")
+
         except Exception as e:
             logger.error(f"Migration error: {e}")
             conn.rollback()

--- a/backend/models.py
+++ b/backend/models.py
@@ -122,8 +122,9 @@ class PriceSnapshot(Base):
     mean_price = Column(Numeric(10, 2), nullable=True)  # Mean price across offers
     best_price = Column(Numeric(10, 2), nullable=True)  # Best in-stock price
     best_store = Column(Text, nullable=True)  # Store with best price
-    discount_pct = Column(Numeric(5, 2), nullable=True)  # Discount percentage vs mean
-    delta = Column(Numeric(5, 2), nullable=True)  # Delta vs site disc-mean
+    discount_pct = Column(Numeric(5, 2), nullable=True)  # Calculated discount: (mean - best) / mean * 100
+    disc_mean_pct = Column(Numeric(5, 2), nullable=True)  # BGO's disc-mean percentage from their API/page
+    delta = Column(Numeric(5, 2), nullable=True)  # Delta: discount_pct - disc_mean_pct
     source_file = Column(Text, nullable=True)  # Which JSON/CSV file this came from
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 

--- a/backend/scripts/fetch_buy_list_prices.py
+++ b/backend/scripts/fetch_buy_list_prices.py
@@ -620,6 +620,7 @@ async def run():
                         "best_price": rnd(best_in_stock, 2),
                         "best_store": best_store,
                         "discount_pct": rnd(disc_pct, 2),
+                        "disc_mean_pct": rnd(site_disc_mean_pct, 2),
                         "delta": rnd(delta, 2),
                         "offers": offers,
                     }

--- a/frontend/src/components/staff/tabs/BuyListTab.jsx
+++ b/frontend/src/components/staff/tabs/BuyListTab.jsx
@@ -383,27 +383,16 @@ export function BuyListTab() {
                 <tr>
                   <th className="px-4 py-3 text-left font-semibold">Rank</th>
                   <th className="px-4 py-3 text-left font-semibold">Game</th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    LPG Status
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    LPG RRP
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    Best Price
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    Store
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    Discount
-                  </th>
-                  <th className="px-4 py-3 text-left font-semibold">
-                    Filter
-                  </th>
-                  <th className="px-4 py-3 text-right font-semibold">
-                    Actions
-                  </th>
+                  <th className="px-4 py-3 text-left font-semibold">LPG Status</th>
+                  <th className="px-4 py-3 text-left font-semibold">LPG RRP</th>
+                  <th className="px-4 py-3 text-left font-semibold">Low $</th>
+                  <th className="px-4 py-3 text-left font-semibold">Mean $</th>
+                  <th className="px-4 py-3 text-left font-semibold">Best $</th>
+                  <th className="px-4 py-3 text-left font-semibold">Store</th>
+                  <th className="px-4 py-3 text-left font-semibold">Discount %</th>
+                  <th className="px-4 py-3 text-left font-semibold">Delta</th>
+                  <th className="px-4 py-3 text-left font-semibold">Filter</th>
+                  <th className="px-4 py-3 text-right font-semibold">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y">
@@ -421,7 +410,7 @@ export function BuyListTab() {
                             className="w-20 px-2 py-1 border rounded"
                           />
                         </td>
-                        <td className="px-4 py-3" colSpan="7">
+                        <td className="px-4 py-3" colSpan="10">
                           <div className="space-y-2">
                             <div className="font-medium">{item.title}</div>
                             <div className="grid grid-cols-2 gap-2">
@@ -537,6 +526,16 @@ export function BuyListTab() {
                         <td className="px-4 py-3 text-gray-700">
                           {formatPrice(item.lpg_rrp)}
                         </td>
+                        <td className="px-4 py-3 text-gray-600">
+                          {item.latest_price?.low_price
+                            ? formatPrice(item.latest_price.low_price)
+                            : "-"}
+                        </td>
+                        <td className="px-4 py-3 text-gray-600">
+                          {item.latest_price?.mean_price
+                            ? formatPrice(item.latest_price.mean_price)
+                            : "-"}
+                        </td>
                         <td className="px-4 py-3 text-gray-700 font-medium">
                           {item.latest_price?.best_price
                             ? formatPrice(item.latest_price.best_price)
@@ -548,7 +547,16 @@ export function BuyListTab() {
                         <td className="px-4 py-3">
                           {item.latest_price?.discount_pct ? (
                             <span className="text-green-700 font-medium">
-                              {item.latest_price.discount_pct.toFixed(0)}%
+                              {item.latest_price.discount_pct.toFixed(1)}%
+                            </span>
+                          ) : (
+                            "-"
+                          )}
+                        </td>
+                        <td className="px-4 py-3">
+                          {item.latest_price?.delta !== null && item.latest_price?.delta !== undefined ? (
+                            <span className={item.latest_price.delta > 0 ? "text-green-700 font-medium" : "text-red-700 font-medium"}>
+                              {item.latest_price.delta > 0 ? "+" : ""}{item.latest_price.delta.toFixed(1)}
                             </span>
                           ) : (
                             "-"


### PR DESCRIPTION
Backend:
- Add disc_mean_pct column to PriceSnapshot model
- Create database migration for disc_mean_pct column
- Update price import endpoint to save disc_mean_pct
- Update buy list response to include low_price, mean_price, disc_mean_pct, and delta
- Scraping script now extracts and saves disc_mean_pct from BGO API

Frontend:
- Add Low $, Mean $, Discount %, and Delta columns to buy list table
- Delta shows color coding: green for positive (better than BGO disc-mean), red for negative
- Improved discount display with one decimal place precision

Price Fields:
- Low $ - Lowest price found across all retailers
- Mean $ - Average price from BoardGameOracle
- Best $ - Best in-stock price (existing)
- Discount % - Calculated: (mean - best) / mean * 100
- Disc-mean % - BGO's discount-mean from their API (stored but not displayed)
- Delta - Difference between our discount and BGO's disc-mean