### PR TITLE
Filter board games by owned status on public page

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -97,7 +97,7 @@ async def get_public_game(
     """Get details for a specific game"""
     service = GameService(db)
     game = service.get_game_by_id(game_id)
-    if not game:
+    if not game or game.status != "OWNED":
         raise GameNotFoundError("Game not found")
 
     return game_to_dict(request, game)

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -83,8 +83,8 @@ class GameService:
         Returns:
             Tuple of (list of Game objects, total count)
         """
-        # Build base query
-        query = select(Game)
+        # Build base query - only show OWNED games for public view
+        query = select(Game).where(Game.status == "OWNED")
 
         # Apply search filter - search across title, designers, and description
         if search and search.strip():
@@ -228,7 +228,7 @@ class GameService:
             List of Game objects
         """
         designer_filter = f"%{designer_name}%"
-        query = select(Game)
+        query = select(Game).where(Game.status == "OWNED")
 
         if hasattr(Game, "designers"):
             query = query.where(Game.designers.ilike(designer_filter))
@@ -491,9 +491,9 @@ class GameService:
         """
         from utils.helpers import calculate_category_counts
 
-        # Only select the columns we need
+        # Only select the columns we need - filter to OWNED games only
         games = self.db.execute(
-            select(Game.id, Game.mana_meeple_category)
+            select(Game.id, Game.mana_meeple_category).where(Game.status == "OWNED")
         ).all()
 
         return calculate_category_counts(games)


### PR DESCRIPTION
- Added status='OWNED' filter to get_filtered_games method to exclude BUY_LIST games from public catalogue
- Added status filter to get_category_counts to ensure counts only reflect OWNED games
- Added status filter to get_games_by_designer for consistent filtering across all public endpoints
- Added status check to get_public_game endpoint to prevent direct access to non-OWNED games via URL

This ensures the public-facing game library only displays games that are physically owned, keeping buy list items private.