### PR TITLE
fix: Player count filtering with expansions and default expansion_type

### DIFF
--- a/backend/bgg_service.py
+++ b/backend/bgg_service.py
@@ -572,6 +572,26 @@ def _extract_comprehensive_game_data(item, bgg_id: int) -> Dict:
             except (ValueError, TypeError):
                 pass
 
+        # Set default expansion_type
+        # Check if title suggests it's standalone (common keywords)
+        standalone_keywords = [
+            "standalone",
+            "stand alone",
+            "stand-alone",
+            "can be played alone",
+            "playable without",
+        ]
+        is_standalone = any(keyword in title_lower for keyword in standalone_keywords)
+
+        if is_standalone:
+            data["expansion_type"] = "both"
+            logger.info(
+                f"Auto-detected standalone expansion for {data['title']}"
+            )
+        else:
+            # Default to requires_base for most expansions
+            data["expansion_type"] = "requires_base"
+
     # Statistics (ratings, complexity, etc.)
     statistics = item.find("statistics")
     if statistics is not None:


### PR DESCRIPTION
## Player Count Filtering Fix
- Add expansion player count calculation to list endpoint
- Update player filtering to include games with expansions that extend player count
- Use subquery to check if any expansion provides requested player count
- Games now show in filters if base OR expansion supports player count

## Expansion Type Default
- Auto-set expansion_type to 'requires_base' by default for all expansions
- Detect standalone expansions from title keywords (standalone, stand alone, etc.)
- Set expansion_type to 'both' for standalone expansions
- Ensures all imported expansions have proper badges

These fixes ensure:
1. Player count filters work correctly with expansion-extended ranges
2. Expansion badges always display (purple for requires_base, indigo for standalone)
3. Users can find games that support their player count via expansions