### PR TITLE
fix: Hide require-base expansions from public view and simplify playe…

### DIFF
--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -86,6 +86,15 @@ class GameService:
         # Build base query
         query = select(Game)
 
+        # Exclude require-base expansions from public view
+        # Only show base games and standalone expansions (expansion_type = 'both' or 'standalone')
+        query = query.where(
+            or_(
+                Game.is_expansion == False,  # Base games
+                Game.expansion_type.in_(["both", "standalone"]),  # Standalone expansions
+            )
+        )
+
         # Apply search filter - search across title, designers, and description
         if search and search.strip():
             search_term = f"%{search.strip()}%"

--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -85,14 +85,16 @@ export default function GameCardPublic({
 
     if (!baseMin || !baseMax) return null;
 
-    const baseRange = baseMin === baseMax ? `${baseMin}` : `${baseMin}-${baseMax}`;
-
+    // If expansion extends player count, show expanded range with asterisk
     if (hasExpansion && expMax > baseMax) {
-      const expRange = expMin === expMax ? `${expMax}` : `${expMin}-${expMax}`;
-      return { base: baseRange, expanded: expRange, hasExpansion: true };
+      const displayMin = expMin || baseMin;
+      const displayMax = expMax;
+      const range = displayMin === displayMax ? `${displayMax}` : `${displayMin}-${displayMax}`;
+      return `${range}*`;
     }
 
-    return { base: baseRange, expanded: null, hasExpansion: false };
+    // Otherwise just show base range
+    return baseMin === baseMax ? `${baseMin}` : `${baseMin}-${baseMax}`;
   };
 
   const transitionClass = prefersReducedMotion ? '' : 'transition-all duration-300';
@@ -222,19 +224,12 @@ export default function GameCardPublic({
               return (
                 <div
                   className="flex items-center gap-1"
-                  aria-label={`${playerCount.base} players${playerCount.hasExpansion ? `, up to ${playerCount.expanded} with expansions` : ''}`}
+                  aria-label={`${playerCount} players`}
                 >
                   <svg className="w-4 h-4 text-emerald-600" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                     <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z"/>
                   </svg>
-                  <span className="font-semibold">
-                    {playerCount.base}
-                    {playerCount.hasExpansion && (
-                      <span className="text-purple-600 ml-1" title="With expansions">
-                        → {playerCount.expanded}*
-                      </span>
-                    )}
-                  </span>
+                  <span className="font-semibold">{playerCount}</span>
                 </div>
               );
             })()}
@@ -267,13 +262,7 @@ export default function GameCardPublic({
               return (
                 <div className="flex items-center gap-2">
                   <span className="text-slate-700">
-                    <span className="font-semibold">Players:</span>{' '}
-                    {playerCount.base}
-                    {playerCount.hasExpansion && (
-                      <span className="text-purple-600 ml-1 font-semibold" title="With expansions">
-                        → {playerCount.expanded}*
-                      </span>
-                    )}
+                    <span className="font-semibold">Players:</span> {playerCount}
                   </span>
                 </div>
               );

--- a/frontend/src/components/staff/LibraryCard.jsx
+++ b/frontend/src/components/staff/LibraryCard.jsx
@@ -13,12 +13,34 @@ export default function LibraryCard({ game, onEditCategory, onDelete }) {
           fallbackClass="w-20 h-20 bg-gradient-to-br from-gray-200 to-gray-300 rounded-xl flex items-center justify-center text-gray-500 text-sm border-2 border-gray-200"
         />
         <div className="flex-1">
-          <div className="font-semibold">{game.title}</div>
+          <div className="flex items-center gap-2">
+            <div className="font-semibold">{game.title}</div>
+            {/* Expansion badges */}
+            {game.is_expansion && (
+              <span className={`text-xs px-2 py-0.5 rounded-full font-semibold ${
+                game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                  ? 'bg-indigo-100 text-indigo-800'
+                  : 'bg-purple-100 text-purple-800'
+              }`}>
+                {game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                  ? 'STANDALONE'
+                  : 'EXPANSION'}
+              </span>
+            )}
+          </div>
           <div className="text-sm text-gray-600">
             {game.min_players ?? "?"}–{game.max_players ?? "?"} · {game.playing_time ?? "?"} mins
+            {game.is_expansion && game.modifies_players_max && (
+              <span className="text-purple-600 ml-1 font-medium">
+                (extends to {game.modifies_players_min ?? game.min_players}-{game.modifies_players_max})
+              </span>
+            )}
           </div>
           <div className="mt-1 text-xs text-gray-500">
             {game.mana_meeple_category ? labelFor(game.mana_meeple_category) : "Uncategorized"}
+            {game.is_expansion && game.base_game_id && (
+              <span className="ml-2 text-purple-600">• Expansion</span>
+            )}
           </div>
 
           <div className="mt-3 flex gap-2">

--- a/frontend/src/pages/GameDetails.jsx
+++ b/frontend/src/pages/GameDetails.jsx
@@ -155,13 +155,10 @@ export default function GameDetails() {
                       <span className="w-2 h-2 rounded-full bg-emerald-500 mr-2" aria-hidden="true"></span>
                       <span className="font-medium text-emerald-800">Players: </span>
                       <span className="font-bold text-emerald-900 ml-1">
-                        {game.min_players ?? "?"}-{game.max_players ?? "?"}
-                        {game.has_player_expansion && game.players_max_with_expansions > game.max_players && (
-                          <span className="text-purple-700 ml-1" title="With expansions">
-                            → {game.players_min_with_expansions ?? game.min_players}-
-                            {game.players_max_with_expansions}*
-                          </span>
-                        )}
+                        {game.has_player_expansion && game.players_max_with_expansions > game.max_players
+                          ? `${game.players_min_with_expansions ?? game.min_players}-${game.players_max_with_expansions}*`
+                          : `${game.min_players ?? "?"}-${game.max_players ?? "?"}`
+                        }
                       </span>
                     </div>
                     


### PR DESCRIPTION
…r count display

## Public View Filtering
- Exclude require-base expansions from public game catalogue
- Only show base games and standalone expansions (expansion_type = 'both' or 'standalone')
- Require-base expansions now ONLY appear in their base game's expansion list

## Player Count Display Simplification
- Remove arrow and purple color from expansion player counts
- Show just expanded range with asterisk: "3-6*" instead of "3-4 → 3-6*"
- Cleaner, more concise display on both game cards and detail pages
- Applied to GameCardPublic.jsx and GameDetails.jsx

## Admin Library View Enhancements
- Add expansion badges to LibraryCard component
- Show expansion type (EXPANSION/STANDALONE) next to title
- Display player count modifications: "(extends to 3-6)"
- Add "• Expansion" indicator in category line
- Purple/indigo color coding for expansion types

These changes ensure:
1. Public users only see playable games (base + standalone)
2. Require-base expansions are discoverable via base game pages
3. Cleaner player count UI without distracting colors/arrows
4. Admins can easily identify and manage expansions in library view