### PR TITLE
fix: Admin library view now uses admin endpoint to show all games inc…

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -132,10 +132,8 @@ export async function getPublicCategoryCounts() {
  */
 export const getGames = async () => {
   try {
-    const response = await api.get("/api/public/games", {
-      params: { page_size: 1000 }
-    });
-    return response.data.items || [];
+    const response = await api.get("/api/admin/games");
+    return response.data || [];
   } catch (error) {
     console.error("Failed to load games:", error);
     return [];


### PR DESCRIPTION
…luding expansions

The admin library view was incorrectly using the public games endpoint, which now filters out require-base expansions. Changed to use the admin endpoint (/api/admin/games) which shows ALL games including all expansion types for proper library management.