### PR TITLE
fix: Manage library now shows only OWNED games with expansion badges

### DIFF
--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -51,8 +51,10 @@ class GameService:
         ).scalar_one_or_none()
 
     def get_all_games(self) -> List[Game]:
-        """Get all games (for admin view)"""
-        return self.db.execute(select(Game)).scalars().all()
+        """Get all games for admin view - only OWNED games, excluding buy list and wishlist"""
+        return self.db.execute(
+            select(Game).where(Game.status == "OWNED")
+        ).scalars().all()
 
     def get_filtered_games(
         self,

--- a/frontend/src/components/staff/LibraryCard.jsx
+++ b/frontend/src/components/staff/LibraryCard.jsx
@@ -3,22 +3,9 @@ import GameImage from "../GameImage";
 import { labelFor } from "../../constants/categories";
 
 export default function LibraryCard({ game, onEditCategory, onDelete }) {
-  // Check if this looks like an expansion based on title or fields
-  const isExpansion = game.is_expansion ||
-    game.title?.toLowerCase().includes('expansion') ||
-    game.title?.toLowerCase().includes('extension');
-
+  // Check if this is an expansion
+  const isExpansion = game.is_expansion;
   const expansionType = game.expansion_type || 'requires_base';
-
-  // Debug: Log the game data to console
-  console.log('LibraryCard game data:', {
-    title: game.title,
-    is_expansion: game.is_expansion,
-    expansion_type: game.expansion_type,
-    base_game_id: game.base_game_id,
-    isExpansion: isExpansion,
-    allKeys: Object.keys(game)
-  });
 
   return (
     <div className="group bg-white border rounded-xl p-4 hover:shadow-md transition">
@@ -30,14 +17,6 @@ export default function LibraryCard({ game, onEditCategory, onDelete }) {
           fallbackClass="w-20 h-20 bg-gradient-to-br from-gray-200 to-gray-300 rounded-xl flex items-center justify-center text-gray-500 text-sm border-2 border-gray-200"
         />
         <div className="flex-1">
-          {/* VISIBLE DEBUG INFO */}
-          <div className="mb-2 p-2 bg-yellow-50 border border-yellow-200 rounded text-xs font-mono">
-            <div>is_expansion: {JSON.stringify(game.is_expansion)}</div>
-            <div>expansion_type: {JSON.stringify(game.expansion_type)}</div>
-            <div>base_game_id: {JSON.stringify(game.base_game_id)}</div>
-            <div>isExpansion calc: {JSON.stringify(isExpansion)}</div>
-          </div>
-
           <div className="flex items-center gap-2 flex-wrap">
             <div className="font-semibold">{game.title}</div>
             {/* Expansion badges */}
@@ -50,12 +29,6 @@ export default function LibraryCard({ game, onEditCategory, onDelete }) {
                 {expansionType === 'both' || expansionType === 'standalone'
                   ? 'STANDALONE'
                   : 'EXPANSION'}
-              </span>
-            )}
-            {/* Show raw is_expansion status for debugging */}
-            {game.is_expansion !== undefined && (
-              <span className="text-xs text-gray-400">
-                [is_expansion: {String(game.is_expansion)}]
               </span>
             )}
           </div>

--- a/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
+++ b/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
@@ -100,6 +100,9 @@ export function ManageLibraryTab() {
                     Name
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">
+                    Type
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">
                     BGG ID
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">
@@ -137,6 +140,32 @@ export function ManageLibraryTab() {
                       <div className="text-sm font-medium text-gray-900">{game.title}</div>
                       {game.year && (
                         <div className="text-xs text-gray-500">{game.year}</div>
+                      )}
+                    </td>
+
+                    {/* Type - Expansion Badge */}
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {game.is_expansion ? (
+                        <div className="flex flex-col gap-1">
+                          <span className={`inline-flex px-2 py-0.5 text-xs font-semibold rounded-full ${
+                            game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                              ? 'bg-indigo-100 text-indigo-800'
+                              : 'bg-purple-100 text-purple-800'
+                          }`}>
+                            {game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                              ? 'STANDALONE'
+                              : 'EXPANSION'}
+                          </span>
+                          {game.modifies_players_max && (
+                            <span className="text-xs text-purple-600">
+                              +{game.modifies_players_min ?? game.min_players}-{game.modifies_players_max}p
+                            </span>
+                          )}
+                        </div>
+                      ) : (
+                        <span className="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">
+                          Base Game
+                        </span>
                       )}
                     </td>
 


### PR DESCRIPTION
Fixes two critical issues in the manage library interface:

1. **Filter out buy_list games**: Modified backend game_service.get_all_games() to only return OWNED games, excluding BUY_LIST and WISHLIST entries

2. **Add expansion badges and info**: Added new "Type" column to ManageLibraryTab
   - Shows "EXPANSION" badge (purple) for require-base expansions
   - Shows "STANDALONE" badge (indigo) for standalone expansions
   - Shows "Base Game" badge (gray) for regular games
   - Displays modified player counts for expansions (+min-max players)

3. **Remove debug info**: Cleaned up LibraryCard component by removing:
   - Visible yellow debug box showing expansion data
   - Console.log statements
   - Debug text showing raw is_expansion status

Backend changes:
- services/game_service.py: Filter get_all_games() to OWNED status only

Frontend changes:
- ManageLibraryTab.jsx: Added Type column with expansion badges
- LibraryCard.jsx: Removed all debug information