### PR TITLE
Fix Wingspan Asia expansion not appearing

### DIFF
--- a/backend/scripts/fix_wingspan_asia.py
+++ b/backend/scripts/fix_wingspan_asia.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Fix Wingspan Asia expansion type to show it as standalone.
+
+Wingspan Asia (BGG ID 266192) is a standalone expansion that can be played
+without the base Wingspan game. This script updates its expansion_type
+from 'requires_base' to 'both' so it appears in the public catalogue.
+"""
+
+import sys
+import os
+
+# Add backend to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from database import SessionLocal
+from models import Game
+from sqlalchemy import or_
+
+def fix_wingspan_asia():
+    """Update Wingspan Asia to be recognized as standalone expansion."""
+    db = SessionLocal()
+    try:
+        # Find Wingspan Asia by BGG ID
+        wingspan_asia = db.query(Game).filter(Game.bgg_id == 266192).first()
+
+        if not wingspan_asia:
+            print("❌ Wingspan Asia (BGG ID 266192) not found in database")
+            print("   It may not have been imported yet.")
+            return False
+
+        print(f"\n✓ Found: {wingspan_asia.title}")
+        print(f"  BGG ID: {wingspan_asia.bgg_id}")
+        print(f"  Current status:")
+        print(f"    - is_expansion: {wingspan_asia.is_expansion}")
+        print(f"    - expansion_type: {wingspan_asia.expansion_type}")
+        print(f"    - base_game_id: {wingspan_asia.base_game_id}")
+        print(f"    - status: {wingspan_asia.status}")
+
+        # Check if it's already set correctly
+        if wingspan_asia.expansion_type == "both":
+            print("\n✓ Wingspan Asia is already set as standalone expansion")
+            return True
+
+        # Update to standalone expansion
+        wingspan_asia.expansion_type = "both"
+
+        # Also verify it's marked as expansion
+        if not wingspan_asia.is_expansion:
+            print("\n  ⚠️  Warning: is_expansion was False, setting to True")
+            wingspan_asia.is_expansion = True
+
+        # Commit changes
+        db.commit()
+
+        print(f"\n✅ Successfully updated Wingspan Asia!")
+        print(f"   expansion_type: {wingspan_asia.expansion_type}")
+        print(f"   This game will now appear in the public catalogue.")
+
+        return True
+
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        db.rollback()
+        return False
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Wingspan Asia Expansion Type Fix")
+    print("=" * 60)
+
+    success = fix_wingspan_asia()
+
+    if success:
+        print("\n✓ Update complete!")
+        sys.exit(0)
+    else:
+        print("\n✗ Update failed")
+        sys.exit(1)

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -357,6 +357,12 @@ class GameService:
             "playtime_max",
             "min_age",
             "nz_designer",
+            # Expansion fields
+            "is_expansion",
+            "expansion_type",
+            "base_game_id",
+            "modifies_players_min",
+            "modifies_players_max",
         ]
 
         for field in updatable_fields:

--- a/frontend/src/components/staff/ExpansionEditModal.jsx
+++ b/frontend/src/components/staff/ExpansionEditModal.jsx
@@ -1,0 +1,187 @@
+// src/components/staff/ExpansionEditModal.jsx
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Modal for editing expansion details of a game
+ * Allows manual configuration of expansion properties
+ */
+export default function ExpansionEditModal({ game, library, onSave, onClose }) {
+  const [formData, setFormData] = useState({
+    is_expansion: false,
+    expansion_type: 'requires_base',
+    base_game_id: null,
+    modifies_players_min: null,
+    modifies_players_max: null,
+  });
+
+  // Initialize form with game data
+  useEffect(() => {
+    if (game) {
+      setFormData({
+        is_expansion: game.is_expansion || false,
+        expansion_type: game.expansion_type || 'requires_base',
+        base_game_id: game.base_game_id || null,
+        modifies_players_min: game.modifies_players_min || null,
+        modifies_players_max: game.modifies_players_max || null,
+      });
+    }
+  }, [game]);
+
+  if (!game) return null;
+
+  // Filter out the current game and expansions from base game selection
+  const possibleBaseGames = library.filter(
+    (g) => g.id !== game.id && !g.is_expansion
+  );
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    // Prepare data - convert empty strings to null
+    const saveData = {
+      is_expansion: formData.is_expansion,
+      expansion_type: formData.is_expansion ? formData.expansion_type : null,
+      base_game_id: formData.is_expansion && formData.base_game_id ? parseInt(formData.base_game_id) : null,
+      modifies_players_min: formData.modifies_players_min ? parseInt(formData.modifies_players_min) : null,
+      modifies_players_max: formData.modifies_players_max ? parseInt(formData.modifies_players_max) : null,
+    };
+
+    onSave(saveData);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white p-6 rounded-t-2xl">
+          <h2 className="text-2xl font-bold">Edit Expansion Details</h2>
+          <p className="text-purple-100 mt-1 text-sm">{game.title}</p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {/* Is Expansion Toggle */}
+          <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+            <input
+              type="checkbox"
+              id="is_expansion"
+              checked={formData.is_expansion}
+              onChange={(e) => handleChange('is_expansion', e.target.checked)}
+              className="w-5 h-5 text-purple-600 rounded focus:ring-2 focus:ring-purple-500"
+            />
+            <label htmlFor="is_expansion" className="font-semibold text-gray-900 cursor-pointer">
+              This is an expansion
+            </label>
+          </div>
+
+          {/* Expansion-specific fields (show only if is_expansion is true) */}
+          {formData.is_expansion && (
+            <div className="space-y-4 border-l-4 border-purple-300 pl-4">
+              {/* Expansion Type */}
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-2">
+                  Expansion Type
+                </label>
+                <select
+                  value={formData.expansion_type}
+                  onChange={(e) => handleChange('expansion_type', e.target.value)}
+                  className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                >
+                  <option value="requires_base">Requires Base Game</option>
+                  <option value="standalone">Standalone (can be played alone)</option>
+                  <option value="both">Both (standalone OR with base game)</option>
+                </select>
+                <p className="mt-1 text-xs text-gray-500">
+                  {formData.expansion_type === 'requires_base' && '🔒 Will NOT appear in public catalogue'}
+                  {formData.expansion_type === 'standalone' && '✅ Will appear in public catalogue'}
+                  {formData.expansion_type === 'both' && '✅ Will appear in public catalogue'}
+                </p>
+              </div>
+
+              {/* Base Game Selection */}
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-2">
+                  Base Game (Optional)
+                </label>
+                <select
+                  value={formData.base_game_id || ''}
+                  onChange={(e) => handleChange('base_game_id', e.target.value ? e.target.value : null)}
+                  className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                >
+                  <option value="">-- None --</option>
+                  {possibleBaseGames.map((g) => (
+                    <option key={g.id} value={g.id}>
+                      {g.title} {g.year ? `(${g.year})` : ''}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-gray-500">
+                  Link this expansion to its base game for better organization
+                </p>
+              </div>
+
+              {/* Player Count Modifications */}
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-2">
+                  Modified Player Count (Optional)
+                </label>
+                <div className="flex gap-3 items-center">
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="1"
+                      max="99"
+                      value={formData.modifies_players_min || ''}
+                      onChange={(e) => handleChange('modifies_players_min', e.target.value)}
+                      placeholder="Min"
+                      className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                    />
+                  </div>
+                  <span className="text-gray-500 font-medium">to</span>
+                  <div className="flex-1">
+                    <input
+                      type="number"
+                      min="1"
+                      max="99"
+                      value={formData.modifies_players_max || ''}
+                      onChange={(e) => handleChange('modifies_players_max', e.target.value)}
+                      placeholder="Max"
+                      className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                    />
+                  </div>
+                </div>
+                <p className="mt-1 text-xs text-gray-500">
+                  If this expansion extends the player count (e.g., "5-6 Player Extension")
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex gap-3 justify-end pt-4 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2.5 rounded-lg border-2 border-gray-300 text-gray-700 font-medium hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-medium hover:from-purple-700 hover:to-indigo-700 transition-all shadow-lg hover:shadow-xl"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
+++ b/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
@@ -4,6 +4,7 @@ import { useStaff } from "../../../context/StaffContext";
 import CategoryFilter from "../../CategoryFilter";
 import { CATEGORY_LABELS } from "../../../constants/categories";
 import { imageProxyUrl } from "../../../api/client";
+import ExpansionEditModal from "../ExpansionEditModal";
 
 /**
  * Manage Library tab - Browse, edit, and delete games in compact table view
@@ -14,12 +15,16 @@ export function ManageLibraryTab() {
     setSelectedCategory,
     counts,
     filteredLibrary,
+    library,
     openEditCategory,
     deleteGameData,
+    updateGameData,
     showToast,
   } = useStaff();
 
   const [searchQuery, setSearchQuery] = useState("");
+  const [expansionModalOpen, setExpansionModalOpen] = useState(false);
+  const [editingExpansion, setEditingExpansion] = useState(null);
 
   // Filter by search query
   const searchFilteredLibrary = useMemo(() => {
@@ -40,6 +45,29 @@ export function ManageLibraryTab() {
     } catch {
       showToast("Delete failed", "error");
     }
+  };
+
+  const handleEditExpansion = (game) => {
+    setEditingExpansion(game);
+    setExpansionModalOpen(true);
+  };
+
+  const handleSaveExpansion = async (expansionData) => {
+    if (!editingExpansion) return;
+
+    try {
+      await updateGameData(editingExpansion.id, expansionData);
+      showToast("Expansion details updated successfully", "success");
+      setExpansionModalOpen(false);
+      setEditingExpansion(null);
+    } catch (error) {
+      showToast("Failed to update expansion details", "error");
+    }
+  };
+
+  const handleCloseExpansionModal = () => {
+    setExpansionModalOpen(false);
+    setEditingExpansion(null);
   };
 
   return (
@@ -202,6 +230,13 @@ export function ManageLibraryTab() {
                     <td className="px-4 py-3 whitespace-nowrap text-right">
                       <div className="flex items-center justify-end gap-2">
                         <button
+                          onClick={() => handleEditExpansion(game)}
+                          className="px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-100 text-indigo-700 hover:bg-indigo-200 transition-colors"
+                          title="Edit expansion details"
+                        >
+                          Edit Exp
+                        </button>
+                        <button
                           onClick={() => openEditCategory(game)}
                           className="px-3 py-1.5 text-xs font-medium rounded-lg bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors"
                         >
@@ -222,6 +257,16 @@ export function ManageLibraryTab() {
           </div>
         )}
       </div>
+
+      {/* Expansion Edit Modal */}
+      {expansionModalOpen && (
+        <ExpansionEditModal
+          game={editingExpansion}
+          library={library}
+          onSave={handleSaveExpansion}
+          onClose={handleCloseExpansionModal}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Add "Edit Exp" button to Manage Library tab allowing admins to manually configure expansion details for any game. This fixes issues where BGG auto-detection misclassifies expansions like Wingspan Asia.

Changes:
- New ExpansionEditModal component for editing expansion properties
  - Toggle is_expansion status
  - Select expansion_type (requires_base/standalone/both)
  - Link to base game from library
  - Set modified player counts for player extension expansions
  - Clear visual feedback on public catalogue visibility

- Update ManageLibraryTab with "Edit Exp" button in actions column
  - Integrates with existing StaffContext updateGameData flow
  - Modal UI matches existing admin interface design

- Backend: Add expansion fields to updateable_fields whitelist
  - is_expansion, expansion_type, base_game_id
  - modifies_players_min, modifies_players_max

This allows fixing Wingspan Asia (BGG 266192) and other standalone expansions that BGG auto-detected as requires_base, making them visible in the public catalogue.