### PR TITLE
fix: Remove incorrect backend. prefix from sleeve_scraper import

### DIFF
--- a/backend/bgg_service.py
+++ b/backend/bgg_service.py
@@ -809,7 +809,7 @@ def _extract_comprehensive_game_data(item, bgg_id: int) -> Dict:
 
     # Fetch sleeve data using Selenium scraper
     try:
-        from backend.services.sleeve_scraper import scrape_sleeve_data
+        from services.sleeve_scraper import scrape_sleeve_data
 
         logger.info(f"Fetching sleeve data for '{data['title']}' (BGG ID: {bgg_id})")
         sleeve_result = scrape_sleeve_data(bgg_id, data['title'])


### PR DESCRIPTION
CRITICAL FIX: This was causing the backend to crash on startup
- Changed 'from backend.services.sleeve_scraper' to 'from services.sleeve_scraper'
- Matches the import pattern used throughout the codebase
- Backend should now start successfully on Render