### PR TITLE
fix: Update status column migration to set default for existing games

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -129,6 +129,20 @@ def run_migrations():
                 conn.commit()
                 logger.info("status column added successfully")
 
+                # Update existing rows to have OWNED status
+                logger.info("Updating existing rows to OWNED status...")
+                conn.execute(
+                    text(
+                        """
+                    UPDATE boardgames
+                    SET status = 'OWNED'
+                    WHERE status IS NULL
+                """
+                    )
+                )
+                conn.commit()
+                logger.info("Updated existing rows with OWNED status")
+
                 # Create index on status
                 conn.execute(
                     text(
@@ -139,6 +153,33 @@ def run_migrations():
                 )
                 conn.commit()
                 logger.info("Created index on status column")
+
+            # Migration 1.6: Ensure all existing games have OWNED status (fix for existing deployments)
+            logger.info("Checking for games with NULL status...")
+            result = conn.execute(
+                text(
+                    """
+                SELECT COUNT(*) FROM boardgames WHERE status IS NULL
+            """
+                )
+            )
+            null_count = result.scalar()
+
+            if null_count > 0:
+                logger.info(f"Found {null_count} games with NULL status, updating to OWNED...")
+                conn.execute(
+                    text(
+                        """
+                    UPDATE boardgames
+                    SET status = 'OWNED'
+                    WHERE status IS NULL
+                """
+                    )
+                )
+                conn.commit()
+                logger.info(f"Updated {null_count} games to OWNED status")
+            else:
+                logger.info("All games have status values set")
 
             # Migration 2: Create buy_list_games table
             result = conn.execute(
@@ -390,6 +431,20 @@ def run_migrations():
                 )
                 conn.commit()
                 logger.info("status column added successfully")
+
+                # Update existing rows to have OWNED status
+                logger.info("Updating existing rows to OWNED status...")
+                conn.execute(
+                    text(
+                        """
+                    UPDATE boardgames
+                    SET status = 'OWNED'
+                    WHERE status IS NULL
+                """
+                    )
+                )
+                conn.commit()
+                logger.info("Updated existing rows with OWNED status")
 
                 # Create index on status
                 conn.execute(


### PR DESCRIPTION
Fixes 500 error on /api/admin/games endpoint caused by NULL status values in existing games. The original migration added the status column with a DEFAULT, but PostgreSQL 11+ doesn't apply defaults to existing rows.

Changes:
- Added UPDATE statement in migration 1.5 to set status='OWNED' for existing rows
- Added migration 1.6 to fix existing deployments where column exists but has NULLs
- Logs count of updated rows for monitoring

This ensures all games have a valid status value ('OWNED' by default) and prevents the query `WHERE status == 'OWNED'` from returning empty results.

Related to: CORS and network errors after recent deployment