### PR TITLE
fix: Resolve PostgreSQL GROUP BY error in game count query

### DIFF
--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -183,9 +183,11 @@ class GameService:
         query = self._apply_sorting(query, sort)
 
         # Get total count before pagination
-        total = self.db.execute(
-            select(func.count()).select_from(query.subquery())
-        ).scalar()
+        # Use a simpler count query that only selects the ID to avoid GROUP BY issues
+        count_query = query.with_only_columns(func.count(Game.id))
+        # Remove ORDER BY for count query (not needed and can cause issues)
+        count_query = count_query.order_by(None)
+        total = self.db.execute(count_query).scalar()
 
         # Apply pagination
         games = (


### PR DESCRIPTION
Fixes GROUP BY error when counting filtered games by simplifying the count query to only select the ID column and removing unnecessary ORDER BY.

The previous approach used select(func.count()).select_from(query.subquery()) which created a subquery with all columns and ORDER BY, causing PostgreSQL to generate GROUP BY errors with complex filters (like player count with expansion subqueries).

New approach:
- Use with_only_columns(func.count(Game.id)) to count only IDs
- Remove ORDER BY from count query with .order_by(None)
- This avoids subquery complexity and GROUP BY issues

Error was: 'column boardgames.year must appear in the GROUP BY clause'