### PR TITLE
Add sleeved status and combine edit dialogs

### DIFF
--- a/backend/api/routers/sleeves.py
+++ b/backend/api/routers/sleeves.py
@@ -28,11 +28,20 @@ def generate_sleeve_shopping_list(
     """
     Generate a sleeve shopping list for selected games
     Groups sleeves by size and counts variations
+    Excludes games that are already sleeved (is_sleeved=True)
     """
     from collections import defaultdict
-    
-    # Fetch all sleeves for selected games
-    sleeves = db.query(Sleeve).filter(Sleeve.game_id.in_(request.game_ids)).all()
+
+    # Get games that are NOT already sleeved
+    unsleeved_game_ids = [
+        g.id for g in db.query(Game).filter(
+            Game.id.in_(request.game_ids),
+            (Game.is_sleeved == False) | (Game.is_sleeved.is_(None))
+        ).all()
+    ]
+
+    # Fetch all sleeves for unsleeved games only
+    sleeves = db.query(Sleeve).filter(Sleeve.game_id.in_(unsleeved_game_ids)).all()
     
     # Group by size (with tolerance for slight variations)
     size_groups = defaultdict(list)

--- a/backend/database.py
+++ b/backend/database.py
@@ -584,6 +584,39 @@ def run_migrations():
             conn.rollback()
             raise
 
+        # Migration: Add is_sleeved column if it doesn't exist
+        try:
+            result = conn.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_name='boardgames' AND column_name='is_sleeved'
+                """
+                )
+            )
+            column_exists = result.fetchone() is not None
+
+            if not column_exists:
+                logger.info("Adding is_sleeved column to boardgames table...")
+                conn.execute(
+                    text(
+                        """
+                        ALTER TABLE boardgames
+                        ADD COLUMN is_sleeved BOOLEAN DEFAULT FALSE
+                    """
+                    )
+                )
+                conn.commit()
+                logger.info("is_sleeved column added successfully")
+            else:
+                logger.info("is_sleeved column already exists")
+
+        except Exception as e:
+            logger.error(f"Migration error (is_sleeved field): {e}")
+            conn.rollback()
+            raise
+
     logger.info("Database migrations completed")
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -56,6 +56,7 @@ class Game(Base):
 
     # Sleeve information
     has_sleeves = Column(String(20), nullable=True)  # 'found', 'not_found', 'error', 'manual', or NULL (not checked)
+    is_sleeved = Column(Boolean, nullable=True, default=False)  # Whether the physical game is already sleeved
 
     # Expansion relationship fields
     is_expansion = Column(Boolean, default=False, nullable=False, index=True)

--- a/frontend/src/components/staff/GameEditModal.jsx
+++ b/frontend/src/components/staff/GameEditModal.jsx
@@ -1,0 +1,321 @@
+// src/components/staff/GameEditModal.jsx
+import React, { useState, useEffect } from 'react';
+import { CATEGORY_KEYS, CATEGORY_LABELS } from '../../constants/categories';
+
+/**
+ * Unified modal for editing all game properties:
+ * - Category assignment
+ * - Expansion details
+ * - Sleeve status
+ */
+export default function GameEditModal({ game, library, onSave, onClose }) {
+  const [activeTab, setActiveTab] = useState('category');
+  const [formData, setFormData] = useState({
+    // Category
+    mana_meeple_category: null,
+    // Expansion
+    is_expansion: false,
+    expansion_type: 'requires_base',
+    base_game_id: null,
+    modifies_players_min: null,
+    modifies_players_max: null,
+    // Sleeve status
+    is_sleeved: false,
+  });
+
+  // Initialize form with game data
+  useEffect(() => {
+    if (game) {
+      setFormData({
+        mana_meeple_category: game.mana_meeple_category || null,
+        is_expansion: game.is_expansion || false,
+        expansion_type: game.expansion_type || 'requires_base',
+        base_game_id: game.base_game_id || null,
+        modifies_players_min: game.modifies_players_min || null,
+        modifies_players_max: game.modifies_players_max || null,
+        is_sleeved: game.is_sleeved || false,
+      });
+    }
+  }, [game]);
+
+  if (!game) return null;
+
+  // Filter out the current game and expansions from base game selection
+  const possibleBaseGames = library.filter(
+    (g) => g.id !== game.id && !g.is_expansion
+  );
+
+  const handleChange = (field, value) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    // Prepare data - convert empty strings to null
+    const saveData = {
+      mana_meeple_category: formData.mana_meeple_category || null,
+      is_expansion: formData.is_expansion,
+      expansion_type: formData.is_expansion ? formData.expansion_type : null,
+      base_game_id: formData.is_expansion && formData.base_game_id ? parseInt(formData.base_game_id) : null,
+      modifies_players_min: formData.modifies_players_min ? parseInt(formData.modifies_players_min) : null,
+      modifies_players_max: formData.modifies_players_max ? parseInt(formData.modifies_players_max) : null,
+      is_sleeved: formData.is_sleeved,
+    };
+
+    onSave(saveData);
+  };
+
+  const tabs = [
+    { id: 'category', label: '📑 Category', icon: '📑' },
+    { id: 'expansion', label: '🎯 Expansion', icon: '🎯' },
+    { id: 'sleeves', label: '🃏 Sleeves', icon: '🃏' },
+  ];
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="bg-gradient-to-r from-purple-600 to-indigo-600 text-white p-6 rounded-t-2xl">
+          <h2 className="text-2xl font-bold">Edit Game</h2>
+          <p className="text-purple-100 mt-1 text-sm">{game.title}</p>
+        </div>
+
+        {/* Tab Navigation */}
+        <div className="border-b border-gray-200 bg-gray-50">
+          <div className="flex">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex-1 px-6 py-4 text-sm font-semibold transition-all ${
+                  activeTab === tab.id
+                    ? 'bg-white text-purple-600 border-b-2 border-purple-600'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="p-6">
+          {/* Category Tab */}
+          {activeTab === 'category' && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 mb-3">
+                  Assign Category
+                </label>
+                <div className="grid grid-cols-1 gap-3">
+                  {CATEGORY_KEYS.map((key) => (
+                    <label
+                      key={key}
+                      className={`flex items-center gap-3 p-4 border-2 rounded-lg cursor-pointer transition-all ${
+                        formData.mana_meeple_category === key
+                          ? 'border-purple-500 bg-purple-50 shadow-md'
+                          : 'border-gray-200 hover:border-purple-300 hover:bg-gray-50'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="category"
+                        value={key}
+                        checked={formData.mana_meeple_category === key}
+                        onChange={(e) => handleChange('mana_meeple_category', e.target.value)}
+                        className="w-5 h-5 text-purple-600"
+                      />
+                      <span className="font-medium text-gray-900">
+                        {CATEGORY_LABELS[key]}
+                      </span>
+                    </label>
+                  ))}
+                  <label
+                    className={`flex items-center gap-3 p-4 border-2 rounded-lg cursor-pointer transition-all ${
+                      formData.mana_meeple_category === null
+                        ? 'border-gray-500 bg-gray-50 shadow-md'
+                        : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="category"
+                      value=""
+                      checked={formData.mana_meeple_category === null}
+                      onChange={() => handleChange('mana_meeple_category', null)}
+                      className="w-5 h-5 text-gray-600"
+                    />
+                    <span className="font-medium text-gray-700">
+                      Uncategorized
+                    </span>
+                  </label>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Expansion Tab */}
+          {activeTab === 'expansion' && (
+            <div className="space-y-6">
+              {/* Is Expansion Toggle */}
+              <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+                <input
+                  type="checkbox"
+                  id="is_expansion"
+                  checked={formData.is_expansion}
+                  onChange={(e) => handleChange('is_expansion', e.target.checked)}
+                  className="w-5 h-5 text-purple-600 rounded focus:ring-2 focus:ring-purple-500"
+                />
+                <label htmlFor="is_expansion" className="font-semibold text-gray-900 cursor-pointer">
+                  This is an expansion
+                </label>
+              </div>
+
+              {/* Expansion-specific fields */}
+              {formData.is_expansion && (
+                <div className="space-y-4 border-l-4 border-purple-300 pl-4">
+                  {/* Expansion Type */}
+                  <div>
+                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                      Expansion Type
+                    </label>
+                    <select
+                      value={formData.expansion_type}
+                      onChange={(e) => handleChange('expansion_type', e.target.value)}
+                      className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                    >
+                      <option value="requires_base">Requires Base Game</option>
+                      <option value="standalone">Standalone (can be played alone)</option>
+                      <option value="both">Both (standalone OR with base game)</option>
+                    </select>
+                    <p className="mt-1 text-xs text-gray-500">
+                      {formData.expansion_type === 'requires_base' && '🔒 Will NOT appear in public catalogue'}
+                      {formData.expansion_type === 'standalone' && '✅ Will appear in public catalogue'}
+                      {formData.expansion_type === 'both' && '✅ Will appear in public catalogue'}
+                    </p>
+                  </div>
+
+                  {/* Base Game Selection */}
+                  <div>
+                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                      Base Game (Optional)
+                    </label>
+                    <select
+                      value={formData.base_game_id || ''}
+                      onChange={(e) => handleChange('base_game_id', e.target.value ? e.target.value : null)}
+                      className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                    >
+                      <option value="">-- None --</option>
+                      {possibleBaseGames.map((g) => (
+                        <option key={g.id} value={g.id}>
+                          {g.title} {g.year ? `(${g.year})` : ''}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-xs text-gray-500">
+                      Link this expansion to its base game for better organization
+                    </p>
+                  </div>
+
+                  {/* Player Count Modifications */}
+                  <div>
+                    <label className="block text-sm font-semibold text-gray-700 mb-2">
+                      Modified Player Count (Optional)
+                    </label>
+                    <div className="flex gap-3 items-center">
+                      <div className="flex-1">
+                        <input
+                          type="number"
+                          min="1"
+                          max="99"
+                          value={formData.modifies_players_min || ''}
+                          onChange={(e) => handleChange('modifies_players_min', e.target.value)}
+                          placeholder="Min"
+                          className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                        />
+                      </div>
+                      <span className="text-gray-500 font-medium">to</span>
+                      <div className="flex-1">
+                        <input
+                          type="number"
+                          min="1"
+                          max="99"
+                          value={formData.modifies_players_max || ''}
+                          onChange={(e) => handleChange('modifies_players_max', e.target.value)}
+                          placeholder="Max"
+                          className="w-full border-2 border-gray-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 rounded-lg px-4 py-2 outline-none transition-all"
+                        />
+                      </div>
+                    </div>
+                    <p className="mt-1 text-xs text-gray-500">
+                      If this expansion extends the player count (e.g., "5-6 Player Extension")
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Sleeves Tab */}
+          {activeTab === 'sleeves' && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-lg">
+                <input
+                  type="checkbox"
+                  id="is_sleeved"
+                  checked={formData.is_sleeved}
+                  onChange={(e) => handleChange('is_sleeved', e.target.checked)}
+                  className="w-5 h-5 text-purple-600 rounded focus:ring-2 focus:ring-purple-500"
+                />
+                <label htmlFor="is_sleeved" className="font-semibold text-gray-900 cursor-pointer">
+                  This game is already sleeved
+                </label>
+              </div>
+
+              <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
+                <p className="text-sm text-gray-700">
+                  <strong>Note:</strong> Games marked as sleeved will be excluded from the sleeve shopping list calculation.
+                  This helps you track which games still need sleeves when generating a shopping list.
+                </p>
+              </div>
+
+              {/* Show sleeve data if available */}
+              {game.has_sleeves === 'found' && (
+                <div className="p-4 bg-green-50 rounded-lg border border-green-200">
+                  <p className="text-sm text-gray-700 mb-2">
+                    <strong>Sleeve Data Available:</strong> This game has sleeve requirements in the database.
+                  </p>
+                  <p className="text-xs text-gray-600">
+                    When generating a shopping list, this game's sleeve requirements will only be included if it's not marked as already sleeved.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex gap-3 justify-end pt-6 mt-6 border-t">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-2.5 rounded-lg border-2 border-gray-300 text-gray-700 font-medium hover:bg-gray-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-2.5 rounded-lg bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-medium hover:from-purple-700 hover:to-indigo-700 transition-all shadow-lg hover:shadow-xl"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
+++ b/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
@@ -4,7 +4,7 @@ import { useStaff } from "../../../context/StaffContext";
 import CategoryFilter from "../../CategoryFilter";
 import { CATEGORY_LABELS } from "../../../constants/categories";
 import { imageProxyUrl, generateSleeveShoppingList } from "../../../api/client";
-import ExpansionEditModal from "../ExpansionEditModal";
+import GameEditModal from "../GameEditModal";
 import SleeveShoppingListModal from "../SleeveShoppingListModal";
 
 /**
@@ -24,8 +24,8 @@ export function ManageLibraryTab() {
   } = useStaff();
 
   const [searchQuery, setSearchQuery] = useState("");
-  const [expansionModalOpen, setExpansionModalOpen] = useState(false);
-  const [editingExpansion, setEditingExpansion] = useState(null);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [editingGame, setEditingGame] = useState(null);
 
   // Game selection state
   const [selectedGames, setSelectedGames] = useState(new Set());
@@ -53,27 +53,27 @@ export function ManageLibraryTab() {
     }
   };
 
-  const handleEditExpansion = (game) => {
-    setEditingExpansion(game);
-    setExpansionModalOpen(true);
+  const handleEditGame = (game) => {
+    setEditingGame(game);
+    setEditModalOpen(true);
   };
 
-  const handleSaveExpansion = async (expansionData) => {
-    if (!editingExpansion) return;
+  const handleSaveGame = async (gameData) => {
+    if (!editingGame) return;
 
     try {
-      await updateGameData(editingExpansion.id, expansionData);
-      showToast("Expansion details updated successfully", "success");
-      setExpansionModalOpen(false);
-      setEditingExpansion(null);
+      await updateGameData(editingGame.id, gameData);
+      showToast("Game details updated successfully", "success");
+      setEditModalOpen(false);
+      setEditingGame(null);
     } catch (error) {
-      showToast("Failed to update expansion details", "error");
+      showToast("Failed to update game details", "error");
     }
   };
 
-  const handleCloseExpansionModal = () => {
-    setExpansionModalOpen(false);
-    setEditingExpansion(null);
+  const handleCloseEditModal = () => {
+    setEditModalOpen(false);
+    setEditingGame(null);
   };
 
   // Game selection handlers
@@ -319,17 +319,11 @@ export function ManageLibraryTab() {
                     <td className="px-4 py-3 whitespace-nowrap text-right">
                       <div className="flex items-center justify-end gap-2">
                         <button
-                          onClick={() => handleEditExpansion(game)}
-                          className="px-3 py-1.5 text-xs font-medium rounded-lg bg-indigo-100 text-indigo-700 hover:bg-indigo-200 transition-colors"
-                          title="Edit expansion details"
-                        >
-                          Edit Exp
-                        </button>
-                        <button
-                          onClick={() => openEditCategory(game)}
+                          onClick={() => handleEditGame(game)}
                           className="px-3 py-1.5 text-xs font-medium rounded-lg bg-purple-100 text-purple-700 hover:bg-purple-200 transition-colors"
+                          title="Edit game details"
                         >
-                          Edit Category
+                          Edit Game
                         </button>
                         <button
                           onClick={() => handleDelete(game)}
@@ -347,13 +341,13 @@ export function ManageLibraryTab() {
         )}
       </div>
 
-      {/* Expansion Edit Modal */}
-      {expansionModalOpen && (
-        <ExpansionEditModal
-          game={editingExpansion}
+      {/* Game Edit Modal */}
+      {editModalOpen && (
+        <GameEditModal
+          game={editingGame}
           library={library}
-          onSave={handleSaveExpansion}
-          onClose={handleCloseExpansionModal}
+          onSave={handleSaveGame}
+          onClose={handleCloseEditModal}
         />
       )}
 


### PR DESCRIPTION
- Add is_sleeved boolean field to Game model to track physically sleeved games
- Update sleeve shopping list endpoint to exclude already-sleeved games
- Create unified GameEditModal component combining category, expansion, and sleeve editing
- Replace separate "Edit Exp" and "Edit Category" buttons with single "Edit Game" button
- Add database migration for is_sleeved field with backward compatibility
- Improve admin workflow by consolidating game editing into one interface

This allows staff to mark games as already sleeved so they won't appear in the sleeve shopping list calculation, making it easier to track which games still need sleeves purchased.