### PR TITLE
feat: Implement JWT authentication to fix auth persistence across dep…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ DATABASE_URL=postgresql://username:password@host:port/database
 # Admin Authentication
 ADMIN_TOKEN=your-secure-admin-token-here
 
+# JWT Authentication
+# Secret key for signing JWT tokens (uses SESSION_SECRET if not set)
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+SESSION_SECRET=your-secure-session-secret-here
+# JWT token expiration in days (default: 7)
+JWT_EXPIRATION_DAYS=7
+
 # BoardGameGeek API Key
 # Required for BGG API v2 authentication
 BGG_API_KEY=your-bgg-api-key-here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,15 @@ export const CATEGORY_LABELS = {
 - `GET /api/public/games/by-designer/{designer_name}` - Games by specific designer
 - `GET /api/public/image-proxy` - Proxy external images with caching
 
-### Admin Endpoints (X-Admin-Token Header Required)
+### Admin Endpoints (JWT Authentication Required)
+**Authentication**: Admin endpoints require JWT token in `Authorization: Bearer <token>` header. Login via `/api/admin/login` to receive JWT token.
+
+**Auth Endpoints**:
+- `POST /api/admin/login` - Login with admin token, returns JWT
+- `POST /api/admin/logout` - Logout (client-side token removal)
+- `GET /api/admin/validate` - Validate current JWT token
+
+**Game Management**:
 - `POST /api/admin/games` - Create new game manually
 - `POST /api/admin/import/bgg?bgg_id={id}&force={bool}` - Import from BoardGameGeek
 - `GET /api/admin/games` - List all games (admin view)
@@ -167,6 +175,8 @@ export const CATEGORY_LABELS = {
 ### Backend Environment Variables (Render)
 ```
 ADMIN_TOKEN=<secure-token-set-in-render-dashboard>
+SESSION_SECRET=<secure-secret-for-jwt-signing>
+JWT_EXPIRATION_DAYS=7
 CORS_ORIGINS=https://manaandmeeples.co.nz,https://www.manaandmeeples.co.nz,https://library.manaandmeeples.co.nz,https://mana-meeples-library-web.onrender.com
 DATABASE_URL=postgresql://tcg_admin:<password>@dpg-d3i3387diees738trbg0-a.singapore-postgres.render.com/tcg_singles
 PUBLIC_BASE_URL=https://mana-meeples-boardgame-list.onrender.com
@@ -175,6 +185,8 @@ PYTHON_VERSION=3.11.9
 
 **Important**: Sensitive credentials should be set securely in Render dashboard, not hardcoded in code.
 Use the `render.yaml` blueprint for infrastructure-as-code deployment with secure secret management.
+
+**JWT Authentication**: The system uses JWT (JSON Web Tokens) for admin authentication, which are stateless and persist across server restarts. The `SESSION_SECRET` is used to sign JWTs. Generate a secure secret with: `python -c "import secrets; print(secrets.token_hex(32))"`
 
 ### Frontend API Configuration
 API base resolution in `config/api.js` with multiple fallback strategies:

--- a/backend/config.py
+++ b/backend/config.py
@@ -81,3 +81,7 @@ if not SESSION_SECRET:
 
 # Session timeout (1 hour by default)
 SESSION_TIMEOUT_SECONDS = int(os.getenv("SESSION_TIMEOUT_SECONDS", "3600"))
+
+# JWT configuration
+# JWT tokens are valid for 7 days by default
+JWT_EXPIRATION_DAYS = int(os.getenv("JWT_EXPIRATION_DAYS", "7"))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ pytest-cov==4.1.0
 slowapi==0.1.9
 sentry-sdk[fastapi]==2.18.0
 selenium>=4.15.0
+PyJWT==2.8.0

--- a/backend/utils/jwt_utils.py
+++ b/backend/utils/jwt_utils.py
@@ -1,0 +1,85 @@
+# utils/jwt_utils.py
+"""
+JWT token utilities for admin authentication.
+Provides stateless authentication that persists across server restarts.
+"""
+import jwt
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, Dict, Any
+
+from config import SESSION_SECRET, JWT_EXPIRATION_DAYS
+
+logger = logging.getLogger(__name__)
+
+# JWT configuration
+JWT_ALGORITHM = "HS256"
+
+
+def generate_jwt_token(client_ip: str) -> str:
+    """
+    Generate a JWT token for admin authentication.
+
+    Args:
+        client_ip: Client IP address for auditing
+
+    Returns:
+        JWT token string
+    """
+    # Token payload
+    payload = {
+        "sub": "admin",  # Subject (admin user)
+        "ip": client_ip,  # Client IP for auditing
+        "iat": datetime.utcnow(),  # Issued at
+        "exp": datetime.utcnow() + timedelta(days=JWT_EXPIRATION_DAYS),  # Expiration
+    }
+
+    # Generate token
+    token = jwt.encode(payload, SESSION_SECRET, algorithm=JWT_ALGORITHM)
+    logger.info(f"Generated JWT token for {client_ip}, expires in {JWT_EXPIRATION_DAYS} days")
+
+    return token
+
+
+def verify_jwt_token(token: str) -> Optional[Dict[str, Any]]:
+    """
+    Verify and decode a JWT token.
+
+    Args:
+        token: JWT token string
+
+    Returns:
+        Decoded token payload if valid, None if invalid or expired
+    """
+    try:
+        # Decode and verify token
+        payload = jwt.decode(token, SESSION_SECRET, algorithms=[JWT_ALGORITHM])
+        return payload
+    except jwt.ExpiredSignatureError:
+        logger.warning("JWT token expired")
+        return None
+    except jwt.InvalidTokenError as e:
+        logger.warning(f"Invalid JWT token: {e}")
+        return None
+
+
+def extract_token_from_header(authorization: Optional[str]) -> Optional[str]:
+    """
+    Extract JWT token from Authorization header.
+
+    Args:
+        authorization: Authorization header value (e.g., "Bearer <token>")
+
+    Returns:
+        Token string if valid format, None otherwise
+    """
+    if not authorization:
+        return None
+
+    # Expected format: "Bearer <token>"
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        logger.warning(f"Invalid Authorization header format: {authorization[:20]}...")
+        return None
+
+    return parts[1]

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -62,7 +62,9 @@ export function useAuth() {
     try {
       await apiAdminLogout();
       setIsAuthenticated(false);
-      // Clear any stored tokens
+      // Clear JWT token (done in apiAdminLogout, but double-check)
+      localStorage.removeItem("JWT_TOKEN");
+      // Also clear legacy token if it exists
       localStorage.removeItem("ADMIN_TOKEN");
       return true;
     } catch (err) {


### PR DESCRIPTION
…loyments

Replace in-memory session storage with stateless JWT tokens to solve authentication failures after Render deployments. This ensures admin users stay logged in even when the backend restarts.

Backend changes:
- Add PyJWT library for token generation and validation
- Create jwt_utils.py with token generation, verification, and extraction
- Update login endpoint to return JWT tokens (7-day expiration)
- Update require_admin_auth dependency to validate JWT from Authorization header
- Maintain backward compatibility with legacy session cookies and token headers
- Add JWT configuration (SESSION_SECRET, JWT_EXPIRATION_DAYS)

Frontend changes:
- Add request interceptor to include JWT in Authorization headers
- Store JWT in localStorage on login
- Clear JWT from localStorage on logout
- Update useAuth hook to manage JWT tokens

Documentation:
- Update CLAUDE.md with JWT authentication details
- Update .env.example with SESSION_SECRET and JWT_EXPIRATION_DAYS
- Document authentication flow in API endpoint descriptions

Benefits:
- Tokens persist across server restarts (stateless)
- No server-side storage required
- Industry-standard authentication approach
- 7-day token expiration for better UX
- Scalable to multi-instance deployments