### PR TITLE
fix: Remove invalid format parameters from Cloudinary upload

### DIFF
--- a/backend/services/cloudinary_service.py
+++ b/backend/services/cloudinary_service.py
@@ -106,9 +106,7 @@ class CloudinaryService:
                 "overwrite": False,  # Don't overwrite existing
                 "resource_type": "image",
                 "type": "upload",
-                "format": "auto",  # Auto-detect best format (WebP/AVIF)
                 "quality": "auto:best",  # Automatic quality optimization
-                "fetch_format": "auto",  # Serve best format based on browser
                 "tags": ["boardgame"],
             }
 


### PR DESCRIPTION
The upload was failing with 'Invalid extension in transformation: auto' because 'format' and 'fetch_format' parameters are only for delivery URLs, not for uploads.

Changes:
- Removed 'format': 'auto' from upload_options
- Removed 'fetch_format': 'auto' from upload_options
- Kept 'quality': 'auto:best' which is valid for uploads

Format conversion to WebP/AVIF happens at delivery time via the get_image_url() method, not during upload.