### PR TITLE
fix: Add required headers for BGG image downloads

### DIFF
--- a/backend/services/cloudinary_service.py
+++ b/backend/services/cloudinary_service.py
@@ -92,8 +92,17 @@ class CloudinaryService:
                 pass
 
             # First, download the image from BGG with proper headers
+            # BGG requires User-Agent and Referer headers to prevent hotlinking
             logger.info(f"Downloading image from BGG: {url}")
-            response = await http_client.get(url)
+
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Referer": "https://boardgamegeek.com/",
+                "Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+            }
+
+            response = await http_client.get(url, headers=headers)
             response.raise_for_status()
 
             image_bytes = response.content


### PR DESCRIPTION
BGG was rejecting requests with 400 Bad Request because we weren't sending proper browser headers.

Changes:
- Added User-Agent header (browser identification)
- Added Referer header (shows we're coming from BGG)
- Added Accept header (proper image MIME types)
- Added Accept-Language header (standard browser header)

BGG uses these headers to prevent hotlinking and bot scraping. With proper headers, the download succeeds and Cloudinary upload works.