### PR TITLE
fix: Remove duplicate folder parameter from Cloudinary upload

### DIFF
--- a/backend/services/cloudinary_service.py
+++ b/backend/services/cloudinary_service.py
@@ -110,11 +110,9 @@ class CloudinaryService:
 
             # Upload with optimizations
             upload_options = {
-                "public_id": public_id,
-                "folder": self.folder,
+                "public_id": public_id,  # Already includes folder path
                 "overwrite": False,  # Don't overwrite existing
                 "resource_type": "image",
-                "type": "upload",
                 "quality": "auto:best",  # Automatic quality optimization
                 "tags": ["boardgame"],
             }


### PR DESCRIPTION
- public_id already includes full folder path (boardgame-library/hash)
- Duplicate folder parameter was causing public_id mismatch
- This was resulting in 404 errors when loading images from Cloudinary URLs