### PR TITLE
fix: Eliminate scrollbar jumping by adding skeleton loaders during in…

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,8 +6,8 @@
 html, body, #root {
   height: 100%;
   scrollbar-gutter: stable;
-  /* Enable CSS scroll anchoring to prevent jumps during content loading */
-  overflow-anchor: auto;
+  /* Disable CSS scroll anchoring - it causes jumps when content loads at bottom */
+  overflow-anchor: none;
 }
 
 body {
@@ -172,8 +172,8 @@ textarea:focus:not(:focus-visible) {
 .game-grid {
   /* Enable layout containment for better performance */
   contain: layout style;
-  /* Prevent scroll anchoring issues in grid */
-  overflow-anchor: auto;
+  /* Disable scroll anchoring to prevent jumps when adding content */
+  overflow-anchor: none;
 }
 
 /* Image container should maintain aspect ratio even before load */

--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -743,23 +743,27 @@ export default function PublicCatalogue() {
 
               {/* Infinite Scroll Trigger & Loading Indicator */}
               {allLoadedItems.length < total && (
-                <div
-                  ref={loadMoreTriggerRef}
-                  className="mt-8 py-8 text-center"
-                >
-                  {loadingMore ? (
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="inline-block animate-spin rounded-full h-8 w-8 border-3 border-emerald-500 border-t-transparent"></div>
-                      <p className="text-sm text-slate-600">
-                        Loading more games...
-                      </p>
+                <>
+                  {/* Show skeleton loaders while loading more to prevent scrollbar jumps */}
+                  {loadingMore && (
+                    <div className="game-grid grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-6 mt-6">
+                      {Array.from({ length: Math.min(pageSize, total - allLoadedItems.length) }).map((_, index) => (
+                        <GameCardSkeleton key={`loading-skeleton-${index}`} />
+                      ))}
                     </div>
-                  ) : (
-                    <p className="text-xs text-slate-400">
-                      Scroll for more • {allLoadedItems.length} of {total}
-                    </p>
                   )}
-                </div>
+
+                  <div
+                    ref={loadMoreTriggerRef}
+                    className="mt-8 py-8 text-center"
+                  >
+                    {!loadingMore && (
+                      <p className="text-xs text-slate-400">
+                        Scroll for more • {allLoadedItems.length} of {total}
+                      </p>
+                    )}
+                  </div>
+                </>
               )}
 
               {/* End of results message */}


### PR DESCRIPTION
…finite scroll

Fixes the rapid up/down scrollbar jumping that occurs when approaching the end of the current content before new items load.

## Root Cause:
When new content loads at the bottom, the page height suddenly increases, causing the scrollbar to recalculate its position. Combined with CSS scroll anchoring, this created rapid jumping behavior.

## Solution:

### 1. Skeleton Loaders During Load More
- ADDED: Skeleton cards appear while loading next page
- Shows exact same grid layout as real cards
- Pre-reserves space for incoming content
- Prevents sudden page height changes that cause scrollbar jumps
- Calculates correct number: Math.min(pageSize, total - allLoadedItems.length)

### 2. Disabled CSS Scroll Anchoring
- CHANGED: overflow-anchor from 'auto' to 'none' on html, body, #root
- CHANGED: overflow-anchor from 'auto' to 'none' on .game-grid
- CSS scroll anchoring was fighting with content additions at bottom
- Caused rapid recalculation of scroll anchor point during loading
- Disabling prevents browser from trying to maintain anchor during content changes

## Expected Behavior Now:
✅ Scrollbar stays stable when approaching end of content ✅ No rapid up/down jumping during load
✅ Smooth visual transition with skeleton loaders
✅ Can continue scrolling while new content loads
✅ Page height changes are pre-allocated, not sudden

## Technical Details:
- Skeleton loaders match exact card dimensions (min-height: 300px)
- Grid layout maintained during loading state
- Only shows skeletons for remaining items (not always full pageSize)
- Skeletons appear above sentinel trigger for smooth UX

Fixes scrollbar jump issue reported after freeze fix.