### PR TITLE
Fix render log warnings and errors

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -188,7 +188,7 @@ async def get_games_by_designer(
 
 
 @router.get("/image-proxy")
-@limiter.limit("60/minute")  # Prevent DDoS while allowing normal browsing
+@limiter.limit("300/minute")  # Allow higher rate for pages with many images
 async def image_proxy(
     request: Request,
     url: str = Query(..., description="Image URL to proxy"),
@@ -207,7 +207,7 @@ async def image_proxy(
     If Cloudinary is disabled:
     - Falls back to direct proxy with caching headers
 
-    Rate limit: 60 requests/minute to prevent abuse.
+    Rate limit: 300 requests/minute to support pages with many images.
     Security: Only proxies images from trusted sources (BGG, local storage).
     """
     # Import dependencies


### PR DESCRIPTION
Fixes three critical issues identified in production logs:

1. Rate Limiting (429 errors):
   - Increased image-proxy rate limit from 60/min to 300/min
   - Prevents rate limit errors when loading pages with many game cards
   - Each catalogue page can load 24+ images simultaneously

2. Cloudinary File Size Errors:
   - Added file size validation before upload (10MB limit)
   - Gracefully skips oversized images and falls back to direct proxy
   - Prevents "File size too large" errors in logs

3. Error Handling:
   - Added specific exception handling for Cloudinary API errors
   - Better logging for debugging file size and rate limit issues
   - Ensures service degrades gracefully when Cloudinary unavailable

Changes:
- backend/api/routers/public.py: Increased rate limit to 300/min
- backend/services/cloudinary_service.py: Added file size check and improved error handling