### PR TITLE
feat: Add AfterGame integration for game session planning

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -58,6 +58,9 @@ class Game(Base):
     has_sleeves = Column(String(20), nullable=True)  # 'found', 'not_found', 'error', 'manual', or NULL (not checked)
     is_sleeved = Column(Boolean, nullable=True, default=False)  # Whether the physical game is already sleeved
 
+    # AfterGame integration
+    aftergame_game_id = Column(String(36), nullable=True, index=True)  # UUID for AfterGame platform game ID
+
     # Expansion relationship fields
     is_expansion = Column(Boolean, default=False, nullable=False, index=True)
     base_game_id = Column(

--- a/backend/utils/helpers.py
+++ b/backend/utils/helpers.py
@@ -298,6 +298,8 @@ def game_to_dict(request: Request, game: Game) -> Dict[str, Any]:
         "expansion_type": getattr(game, "expansion_type", None),
         "modifies_players_min": getattr(game, "modifies_players_min", None),
         "modifies_players_max": getattr(game, "modifies_players_max", None),
+        # AfterGame integration
+        "aftergame_game_id": getattr(game, "aftergame_game_id", None),
     }
 
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -229,6 +229,16 @@ export async function bulkUpdateNZDesigners(csv_data) {
 }
 
 /**
+ * Bulk update AfterGame game IDs from CSV
+ * @param {string} csv_data - CSV text data (format: bgg_id,aftergame_game_id[,title])
+ * @returns {Promise<Object>} Update results
+ */
+export async function bulkUpdateAfterGameIDs(csv_data) {
+  const r = await api.post("/api/admin/bulk-update-aftergame-ids", { csv_data });
+  return r.data;
+}
+
+/**
  * Re-import all games with enhanced BGG data
  * @returns {Promise<Object>} Re-import initiation confirmation
  */

--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -3,6 +3,7 @@ import React, { useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { labelFor } from "../../constants/categories";
 import GameImage from "../GameImage";
+import { getAfterGameCreateUrl } from "../../constants/aftergame";
 
 export default function GameCardPublic({
   game,
@@ -320,16 +321,31 @@ export default function GameCardPublic({
               </div>
             )}
 
-            {/* View Full Details Link */}
-            <Link
-              to={href}
-              className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-semibold text-sm mt-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 rounded px-2 py-1"
-            >
-              <span>View Full Details</span>
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
+            {/* Action Buttons */}
+            <div className="flex flex-wrap gap-2 mt-3">
+              {/* Plan a Game Button */}
+              <a
+                href={getAfterGameCreateUrl(game.aftergame_game_id)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-gradient-to-r from-teal-500 to-emerald-500 text-white font-semibold text-sm hover:from-teal-600 hover:to-emerald-600 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
+                aria-label="Plan a game session on AfterGame"
+              >
+                <span role="img" aria-label="Game planning">🎲</span>
+                <span>Plan a Game</span>
+              </a>
+
+              {/* View Full Details Link */}
+              <Link
+                to={href}
+                className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-semibold text-sm px-2 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 rounded"
+              >
+                <span>View Full Details</span>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/staff/BulkPanels.jsx
+++ b/frontend/src/components/staff/BulkPanels.jsx
@@ -40,3 +40,38 @@ export function BulkCategorizePanel({ value, onChange, onSubmit }) {
     </div>
   );
 }
+
+export function BulkAfterGamePanel({ value, onChange, onSubmit }) {
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow">
+      <h3 className="text-lg font-semibold mb-2 flex items-center gap-2">
+        🎲 Bulk Update AfterGame IDs (CSV)
+      </h3>
+      <p className="text-sm text-gray-600 mb-2">
+        Columns: <code>bgg_id,aftergame_game_id[,title]</code>. AfterGame game ID should be a UUID (e.g.,{" "}
+        <code>ac3a5f77-3e19-47af-a61a-d648d04b02e2</code>).
+      </p>
+      <div className="mb-3 p-3 bg-emerald-50 rounded-lg border border-emerald-200">
+        <p className="text-xs text-gray-700">
+          <strong>Example CSV format:</strong><br />
+          <code className="text-xs">
+            bgg_id,aftergame_game_id,title<br />
+            174430,ac3a5f77-3e19-47af-a61a-d648d04b02e2,Gloomhaven<br />
+            167791,bd4b6e88-4c2a-48bf-b71b-e759e15c13f3,Terraforming Mars
+          </code>
+        </p>
+      </div>
+      <textarea
+        className="w-full h-40 border rounded-lg p-2 font-mono text-sm"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="bgg_id,aftergame_game_id,title&#10;174430,ac3a5f77-3e19-47af-a61a-d648d04b02e2,Gloomhaven"
+      />
+      <div className="mt-2">
+        <button className="px-4 py-2 rounded bg-emerald-600 text-white hover:bg-emerald-700" onClick={onSubmit}>
+          Update AfterGame IDs
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/staff/GameEditModal.jsx
+++ b/frontend/src/components/staff/GameEditModal.jsx
@@ -21,6 +21,8 @@ export default function GameEditModal({ game, library, onSave, onClose }) {
     modifies_players_max: null,
     // Sleeve status
     is_sleeved: false,
+    // AfterGame integration
+    aftergame_game_id: null,
   });
 
   // Initialize form with game data
@@ -34,6 +36,7 @@ export default function GameEditModal({ game, library, onSave, onClose }) {
         modifies_players_min: game.modifies_players_min || null,
         modifies_players_max: game.modifies_players_max || null,
         is_sleeved: game.is_sleeved || false,
+        aftergame_game_id: game.aftergame_game_id || null,
       });
     }
   }, [game]);
@@ -64,6 +67,7 @@ export default function GameEditModal({ game, library, onSave, onClose }) {
       modifies_players_min: formData.modifies_players_min ? parseInt(formData.modifies_players_min) : null,
       modifies_players_max: formData.modifies_players_max ? parseInt(formData.modifies_players_max) : null,
       is_sleeved: formData.is_sleeved,
+      aftergame_game_id: formData.aftergame_game_id || null,
     };
 
     onSave(saveData);
@@ -73,6 +77,7 @@ export default function GameEditModal({ game, library, onSave, onClose }) {
     { id: 'category', label: '📑 Category', icon: '📑' },
     { id: 'expansion', label: '🎯 Expansion', icon: '🎯' },
     { id: 'sleeves', label: '🃏 Sleeves', icon: '🃏' },
+    { id: 'integration', label: '🎲 AfterGame', icon: '🎲' },
   ];
 
   return (
@@ -292,6 +297,54 @@ export default function GameEditModal({ game, library, onSave, onClose }) {
                   </p>
                   <p className="text-xs text-gray-600">
                     When generating a shopping list, this game's sleeve requirements will only be included if it's not marked as already sleeved.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* AfterGame Integration Tab */}
+          {activeTab === 'integration' && (
+            <div className="space-y-4">
+              <div className="p-4 bg-gradient-to-r from-emerald-50 to-teal-50 rounded-lg border border-emerald-200">
+                <p className="text-sm text-gray-700 mb-2">
+                  <strong>🎲 AfterGame Integration</strong>
+                </p>
+                <p className="text-xs text-gray-600">
+                  Connect this game to AfterGame to enable players to plan game sessions directly from the library.
+                  Enter the AfterGame game ID (UUID format) to enable deep linking.
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="aftergame_game_id" className="block text-sm font-semibold text-gray-700 mb-2">
+                  AfterGame Game ID
+                </label>
+                <input
+                  type="text"
+                  id="aftergame_game_id"
+                  value={formData.aftergame_game_id || ''}
+                  onChange={(e) => handleChange('aftergame_game_id', e.target.value.trim() || null)}
+                  placeholder="e.g., ac3a5f77-3e19-47af-a61a-d648d04b02e2"
+                  className="w-full border-2 border-gray-300 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-200 rounded-lg px-4 py-2 outline-none transition-all font-mono text-sm"
+                />
+                <p className="mt-2 text-xs text-gray-500">
+                  Find the game ID in AfterGame's URL or database. Format: UUID (36 characters with dashes)
+                </p>
+              </div>
+
+              {formData.aftergame_game_id && (
+                <div className="p-3 bg-green-50 rounded-lg border border-green-200">
+                  <p className="text-sm text-green-800">
+                    ✅ When set, the "Plan a Game" button will link directly to this specific game on AfterGame
+                  </p>
+                </div>
+              )}
+
+              {!formData.aftergame_game_id && (
+                <div className="p-3 bg-amber-50 rounded-lg border border-amber-200">
+                  <p className="text-sm text-amber-800">
+                    ℹ️ Without an AfterGame ID, the "Plan a Game" button will link to the generic game creation page
                   </p>
                 </div>
               )}

--- a/frontend/src/constants/aftergame.js
+++ b/frontend/src/constants/aftergame.js
@@ -1,0 +1,43 @@
+// frontend/src/constants/aftergame.js
+/**
+ * AfterGame Integration Constants
+ *
+ * URLs and helper functions for integrating with AfterGame platform
+ * to enable game session planning from the board game library.
+ */
+
+/**
+ * AfterGame URLs for Mana & Meeples group
+ */
+export const AFTERGAME_URLS = {
+  // Main group page
+  GROUP: 'https://aftergame.app/groups/mana---meeples-9373',
+
+  // View upcoming events
+  UPCOMING_EVENTS: 'https://aftergame.app/groups/mana---meeples-9373/events?initialPast=false',
+
+  // Base URL for creating new game events
+  CREATE_GAME_BASE: 'https://aftergame.app/events/create?type=SPECIFIC_GAME&placeId=8f340e1e-05dd-4d98-86a4-4b4a47512d40&initialGroupId=9b196948-f86f-4600-b8be-cfea3768c9e5&initialGroupName=Mana%20%26%20Meeples%20Timaru'
+};
+
+/**
+ * Generate AfterGame URL for planning a game session
+ *
+ * @param {string|null} aftergameGameId - AfterGame UUID for the specific game
+ * @returns {string} URL to create game session on AfterGame
+ *
+ * @example
+ * // With specific game ID
+ * getAfterGameCreateUrl('ac3a5f77-3e19-47af-a61a-d648d04b02e2')
+ * // Returns: https://aftergame.app/events/create?...&gameId=ac3a5f77-3e19-47af-a61a-d648d04b02e2
+ *
+ * // Without game ID (generic)
+ * getAfterGameCreateUrl(null)
+ * // Returns: https://aftergame.app/events/create?...
+ */
+export function getAfterGameCreateUrl(aftergameGameId) {
+  if (!aftergameGameId) {
+    return AFTERGAME_URLS.CREATE_GAME_BASE;
+  }
+  return `${AFTERGAME_URLS.CREATE_GAME_BASE}&gameId=${aftergameGameId}`;
+}


### PR DESCRIPTION
Implements deep linking to AfterGame platform for organizing game sessions at Mana & Meeples. Users can now plan games directly from the library with per-game deep linking using AfterGame game IDs.

**Backend Changes:**
- Add aftergame_game_id column to boardgames table (UUID format)
- Implement database migration for new column with index
- Update API serialization to include aftergame_game_id field
- Add bulk update endpoint: POST /api/admin/bulk-update-aftergame-ids
  - CSV format: bgg_id,aftergame_game_id[,title]
  - Returns updated/not_found/errors lists

**Frontend Changes:**
- Create aftergame.js constants with URLs and helper function
  - AFTERGAME_URLS for group, events, and game creation
  - getAfterGameCreateUrl() for per-game deep linking
- Add "Plan a Game" button to game card expanded details
  - Links to specific game if aftergame_game_id set
  - Falls back to generic creation page if null
  - Opens in new tab with accessibility labels
- Add AfterGame tab to game edit modal
  - Input field for aftergame_game_id (UUID format)
  - Helpful guidance and validation feedback
- Add bulk AfterGame ID upload to Advanced Tools
  - CSV textarea with example format
  - Log file download with results
  - Integrated with existing bulk operation patterns

**Features:**
- Per-game deep linking when aftergame_game_id is populated
- Graceful fallback to generic planning page when ID is null
- Accessibility-compliant with emoji labels and ARIA attributes
- Admin UI for both individual and bulk ID management
- Full emoji + text buttons as requested