### PR TITLE
fix: Add fallback for missing Cloudinary images and proper image resi…

### DIFF
--- a/frontend/src/components/GameImage.jsx
+++ b/frontend/src/components/GameImage.jsx
@@ -111,7 +111,7 @@ export default function GameImage({
       {/* Only render img when shouldLoadImage is true (for IntersectionObserver) */}
       {shouldLoadImage && (
         <img
-          src={imageProxyUrl(url)}
+          src={imageProxyUrl(url, 'original', width, height)}
           srcSet={srcSet}
           sizes={srcSet ? sizes : undefined}
           alt={alt || "Game cover image"}

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -92,17 +92,24 @@ function getBGGImageVariant(url, size) {
  * Priority order: _original > _d (detail) > _md (medium) > _mt (medium thumb) > _t (thumbnail)
  *
  * @param {string} url - The original image URL
- * @param {string} size - Optional size variant for responsive images
+ * @param {string} size - Optional size variant for responsive images ('original'|'detail'|'medium'|'medium-thumb'|'thumbnail')
+ * @param {number} width - Optional width for Cloudinary transformation
+ * @param {number} height - Optional height for Cloudinary transformation
  * @returns {string|null} - Proxied image URL or null if no URL provided
  */
-export function imageProxyUrl(url, size = 'original') {
+export function imageProxyUrl(url, size = 'original', width = null, height = null) {
   if (!url) return null;
 
   // For BGG images, optimize for requested quality
   if (url.includes('cf.geekdo-images.com')) {
     const optimizedUrl = getBGGImageVariant(url, size);
-    // Backend will handle fallback chain if requested size doesn't exist
-    return `${API_BASE}/api/public/image-proxy?url=${encodeURIComponent(optimizedUrl)}`;
+    let proxyUrl = `${API_BASE}/api/public/image-proxy?url=${encodeURIComponent(optimizedUrl)}`;
+
+    // Add width/height parameters for Cloudinary transformations
+    if (width) proxyUrl += `&width=${width}`;
+    if (height) proxyUrl += `&height=${height}`;
+
+    return proxyUrl;
   }
 
   // For non-BGG images, proxy as-is


### PR DESCRIPTION
…zing

This commit fixes two critical issues with image delivery:

1. Missing/Oversized Images
   - Add fallback to direct proxy when Cloudinary URL generation fails
   - Handle gracefully when images are too large for Cloudinary (>10MB)
   - Log warnings when falling back to direct proxy

2. Image Resizing Not Working
   - Changed default crop mode from 'fill' to 'limit' for proper aspect ratio
   - Updated frontend imageProxyUrl() to accept and pass width/height params
   - Modified GameImage component to pass dimensions to proxy endpoint
   - Add debug logging to verify Cloudinary transformation URLs

Backend changes (api/routers/public.py):
- Wrap Cloudinary URL generation in try/catch
- Check if Cloudinary URL differs from original before redirecting
- Fall through to direct proxy if Cloudinary fails

Backend changes (services/cloudinary_service.py):
- Use 'limit' crop mode instead of 'fill' to maintain aspect ratio
- Only apply gravity for 'fill' mode
- Add debug logging for generated URLs
- Improve error logging with specific failure reasons

Frontend changes (config/api.js):
- Add width/height parameters to imageProxyUrl function signature
- Append width/height as query params when provided

Frontend changes (components/GameImage.jsx):
- Pass width/height props to imageProxyUrl for proper resizing

Result:
- Images now resize properly via Cloudinary transformations
- Oversized/missing images fallback to direct proxy gracefully
- No more full-size images causing layout issues