### PR TITLE
Fix exception handling in render process

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -41,7 +41,6 @@ class Game(Base):
     mana_meeple_category = Column(String(50), nullable=True, index=True)
     description = Column(Text, nullable=True)
     designers = Column(JSON, nullable=True)  # Store as JSON array
-    designers_text = Column(Text, nullable=True)  # Denormalized text for fast searching with GIN index
     publishers = Column(JSON, nullable=True)  # Store as JSON array
     mechanics = Column(JSON, nullable=True)  # Store as JSON array
     artists = Column(JSON, nullable=True)  # Store as JSON array
@@ -113,11 +112,6 @@ class Game(Base):
         # Complex filtering (category + year + rating for sorting)
         Index("idx_category_year_rating", "mana_meeple_category", "year", "average_rating",
               postgresql_where=Column("status") == "OWNED"),
-
-        # GIN index for fast designer text search (requires pg_trgm extension)
-        # Note: This will be created manually in migration due to GIN requirements
-        # Index("idx_designers_gin", "designers_text", postgresql_using="gin",
-        #       postgresql_ops={"designers_text": "gin_trgm_ops"}),
 
         # Sprint 4 Data Integrity Constraints
         CheckConstraint("year >= 1900 AND year <= 2100", name="valid_year"),

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -23,36 +23,6 @@ class GameService:
 
     def __init__(self, db: Session):
         self.db = db
-        self._has_designers_text_col = None  # Cache column existence check
-
-    def _has_designers_text_column(self) -> bool:
-        """
-        Check if designers_text column exists AND is populated in the database.
-        Only returns True if the column exists and has non-NULL values.
-        Caches result for performance.
-        """
-        if self._has_designers_text_col is None:
-            try:
-                inspector = inspect(self.db.get_bind())
-                columns = [col['name'] for col in inspector.get_columns('boardgames')]
-
-                # Check if column exists in schema
-                if 'designers_text' not in columns:
-                    self._has_designers_text_col = False
-                else:
-                    # Column exists - check if it's actually populated
-                    # Query for any row with non-NULL designers_text
-                    result = self.db.execute(
-                        select(func.count(Game.id)).where(Game.designers_text.isnot(None))
-                    ).scalar()
-
-                    # Only use designers_text if at least one row has data
-                    self._has_designers_text_col = result > 0
-
-            except Exception as e:
-                logger.warning(f"Could not inspect database schema: {e}")
-                self._has_designers_text_col = False
-        return self._has_designers_text_col
 
     def get_game_by_id(self, game_id: int) -> Optional[Game]:
         """
@@ -133,12 +103,8 @@ class GameService:
             search_term = f"%{search.strip()}%"
             search_conditions = [Game.title.ilike(search_term)]
 
-            # Add designer search - use designers_text if available (Sprint 4 GIN index optimization)
-            # Check if column exists in actual database schema (not just model definition)
-            if self._has_designers_text_column():
-                search_conditions.append(Game.designers_text.ilike(search_term))
-            elif hasattr(Game, "designers"):
-                # Cast JSON to text for searching (works in both SQLite and PostgreSQL)
+            # Add designer search - cast JSON to text for searching (works in both SQLite and PostgreSQL)
+            if hasattr(Game, "designers"):
                 search_conditions.append(cast(Game.designers, String).ilike(search_term))
 
             # Add description search for keyword functionality
@@ -147,16 +113,11 @@ class GameService:
 
             query = query.where(or_(*search_conditions))
 
-        # Apply designer filter using optimized designers_text column
-        # This uses the GIN index for 10-100x faster searches (when available)
+        # Apply designer filter
         if designer and designer.strip():
             designer_filter = f"%{designer.strip()}%"
-
-            # Check if column exists in actual database schema (not just model definition)
-            if self._has_designers_text_column():
-                query = query.where(Game.designers_text.ilike(designer_filter))
-            elif hasattr(Game, "designers"):
-                # Cast JSON to text for searching (required for SQLite and PostgreSQL)
+            # Cast JSON to text for searching (works in both SQLite and PostgreSQL)
+            if hasattr(Game, "designers"):
                 query = query.where(cast(Game.designers, String).ilike(designer_filter))
 
         # Apply NZ designer filter
@@ -303,7 +264,6 @@ class GameService:
     def get_games_by_designer(self, designer_name: str) -> List[Game]:
         """
         Get all games by a specific designer.
-        Uses optimized designers_text column with GIN index for fast searching.
 
         Args:
             designer_name: Name of the designer to search for
@@ -314,12 +274,8 @@ class GameService:
         designer_filter = f"%{designer_name}%"
         query = select(Game).where(Game.status == "OWNED")
 
-        # Use optimized designers_text column with GIN index (10-100x faster)
-        # Check if column exists in actual database schema (not just model definition)
-        if self._has_designers_text_column():
-            query = query.where(Game.designers_text.ilike(designer_filter))
-        elif hasattr(Game, "designers"):
-            # Cast JSON to text for searching (required for SQLite and PostgreSQL)
+        # Cast JSON to text for searching (works in both SQLite and PostgreSQL)
+        if hasattr(Game, "designers"):
             query = query.where(cast(Game.designers, String).ilike(designer_filter))
 
         return self.db.execute(query).scalars().all()


### PR DESCRIPTION
The designers_text column was defined in the SQLAlchemy model but never created in the production database via migration. This caused 500 errors when querying games:
- psycopg2.errors.UndefinedColumn: column boardgames.designers_text does not exist

Changes:
- Remove designers_text column from Game model (models.py)
- Remove commented-out GIN index configuration referencing designers_text
- Simplify game_service.py to use JSON designers column directly
- Remove _has_designers_text_column() method and defensive checks
- Update search and filter logic to use cast(Game.designers, String)

The application now uses the existing JSON designers column for all designer searches, which works correctly in PostgreSQL.

Fixes the 500 error on /api/admin/games endpoint.