### PR TITLE
feat: Add Aftergame icon to 'Plan a Game' buttons

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -331,7 +331,11 @@ export default function GameCardPublic({
                 className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-gradient-to-r from-teal-500 to-emerald-500 text-white font-semibold text-sm hover:from-teal-600 hover:to-emerald-600 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
                 aria-label="Plan a game session on AfterGame"
               >
-                <span role="img" aria-label="Game planning">🎲</span>
+                <img
+                  src="/Aftergame_Icon_Logo_V3-Light.webp"
+                  alt="AfterGame"
+                  className="w-5 h-5"
+                />
                 <span>Plan a Game</span>
               </a>
 

--- a/frontend/src/pages/GameDetails.jsx
+++ b/frontend/src/pages/GameDetails.jsx
@@ -302,7 +302,11 @@ export default function GameDetails() {
                         className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-teal-500 to-emerald-500 text-white font-medium rounded-xl hover:from-teal-600 hover:to-emerald-600 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
                         aria-label="Plan a game session on AfterGame (opens in new tab)"
                       >
-                        <span role="img" aria-label="Game planning" className="text-xl mr-2">🎲</span>
+                        <img
+                          src="/Aftergame_Icon_Logo_V3-Light.webp"
+                          alt="AfterGame"
+                          className="w-6 h-6 mr-2"
+                        />
                         Plan a Game
                         <span className="sr-only"> (opens in new tab)</span>
                       </a>


### PR DESCRIPTION
- Replace dice emoji with Aftergame_Icon_Logo_V3-Light.webp icon
- Updated GameDetails.jsx button (w-6 h-6 sizing)
- Updated GameCardPublic.jsx button (w-5 h-5 sizing)
- Icon positioned on left side of button text
- Improved branding consistency with AfterGame integration