### PR TITLE
fix: Add limit(1) to last-updated query to prevent multiple rows error

### DIFF
--- a/backend/api/routers/buy_list.py
+++ b/backend/api/routers/buy_list.py
@@ -773,7 +773,7 @@ async def get_last_price_update(db: Session = Depends(get_db)):
     """Get timestamp of last price update"""
     try:
         latest_snapshot = db.execute(
-            select(PriceSnapshot).order_by(desc(PriceSnapshot.checked_at))
+            select(PriceSnapshot).order_by(desc(PriceSnapshot.checked_at)).limit(1)
         ).scalar_one_or_none()
 
         if not latest_snapshot:


### PR DESCRIPTION
The /api/admin/buy-list/last-updated endpoint was failing with "Multiple rows were found when one or none was required" when multiple price snapshots had the same checked_at timestamp. Added .limit(1) to ensure only one row is returned from the query.