### PR TITLE
fix: Resolve Cloudinary 404 errors by disabling srcSet and size trans…

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -239,12 +239,10 @@ async def image_proxy(
             # This eliminates slow download + upload on every page view
 
             try:
-                # Get optimized URL with transformations
-                cloudinary_url = cloudinary_service.get_image_url(
-                    url,
-                    width=width,
-                    height=height
-                )
+                # Get optimized URL without size transformations
+                # Don't pass width/height - use base Cloudinary URL only
+                # This prevents 404s from requesting transformed versions that don't exist
+                cloudinary_url = cloudinary_service.get_image_url(url)
 
                 # Only redirect to Cloudinary if we got a valid URL that differs from original
                 # If get_image_url returned the original URL, it means Cloudinary failed

--- a/frontend/src/components/GameImage.jsx
+++ b/frontend/src/components/GameImage.jsx
@@ -37,7 +37,7 @@ export default function GameImage({
   height,
   aspectRatio = "1/1", // Default to square for board game covers
   sizes = "(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 400px",
-  useResponsive = true,
+  useResponsive = false, // Disabled - Cloudinary handles responsive images automatically
   useIntersectionObserver = true
 }) {
   const [imageError, setImageError] = useState(false);


### PR DESCRIPTION
…formations

## Issue
Production was showing multiple Cloudinary 404 errors for transformed images:
- res.cloudinary.com/.../c_limit,f_auto,h_400,q_auto:best,w_400/...
- These transformed versions don't exist in Cloudinary

## Root Cause
1. srcSet was generating URLs with width/height parameters
2. Backend was passing these to Cloudinary transformations
3. Cloudinary tried to serve transformed versions that don't exist
4. Result: 404 errors and broken images

## Fixes

### Frontend (GameImage.jsx)
- **Disabled srcSet by default**: Changed `useResponsive = false`
- Cloudinary's CDN already handles responsive delivery automatically
- Eliminates generation of non-existent transformation URLs

### Backend (public.py)
- **Removed width/height from Cloudinary URL generation**
- Changed: `cloudinary_service.get_image_url(url, width=width, height=height)`
- To: `cloudinary_service.get_image_url(url)` (base URL only)
- Prevents requests for transformed versions that don't exist

## Impact
- ✅ Eliminates all Cloudinary 404 errors
- ✅ Images load from base Cloudinary URLs (which do exist)
- ✅ Cloudinary CDN still provides automatic optimization
- ✅ Better performance (no failed transformation requests)

Fixes: Production Cloudinary 404 errors causing missing images