### PR TITLE
Fix 'Multiple rows found' error in buy list update

### DIFF
--- a/backend/api/routers/buy_list.py
+++ b/backend/api/routers/buy_list.py
@@ -423,6 +423,7 @@ async def update_buy_list_game(
             select(PriceSnapshot)
             .where(PriceSnapshot.game_id == buy_list_entry.game_id)
             .order_by(desc(PriceSnapshot.checked_at))
+            .limit(1)
         ).scalar_one_or_none()
 
         logger.info(f"Updated buy list entry {buy_list_id}")


### PR DESCRIPTION
When updating a buy list entry, the query to fetch the latest price snapshot was using .scalar_one_or_none() without a LIMIT clause.

If multiple price snapshots existed with the same checked_at timestamp for a game, SQLAlchemy would throw:
  "Multiple rows were found when one or none was required"

Added .limit(1) to ensure only the first (most recent) price snapshot is returned, even when multiple snapshots have identical timestamps.

This fixes the 500 error when trying to move games from buy list to owned.