### PR TITLE
Add comprehensive type hints to backend Python code

### DIFF
--- a/backend/bgg_service.py
+++ b/backend/bgg_service.py
@@ -5,7 +5,8 @@ Sprint 5: Enhanced with circuit breaker for fail-fast during BGG outages
 """
 import asyncio
 import xml.etree.ElementTree as ET
-from typing import Dict
+from typing import Dict, Any
+from xml.etree.ElementTree import Element
 import httpx
 import logging
 import html
@@ -43,7 +44,7 @@ def _is_bgg_available() -> bool:
     return bgg_circuit_breaker.current_state == "closed"
 
 
-async def fetch_bgg_thing(bgg_id: int, retries: int = HTTP_RETRIES) -> Dict:
+async def fetch_bgg_thing(bgg_id: int, retries: int = HTTP_RETRIES) -> Dict[str, Any]:
     """
     Enhanced BGG data fetcher that captures comprehensive game information
     including descriptions, mechanics, designers, publishers, and ratings.
@@ -406,14 +407,14 @@ async def fetch_bgg_thing(bgg_id: int, retries: int = HTTP_RETRIES) -> Dict:
         )
 
 
-def _strip_namespace(root):
+def _strip_namespace(root: Element) -> None:
     """Remove XML namespaces from element tags"""
     for elem in root.iter():
         if "}" in elem.tag:
             elem.tag = elem.tag.split("}", 1)[1]
 
 
-def _extract_comprehensive_game_data(item, bgg_id: int) -> Dict:
+def _extract_comprehensive_game_data(item: Element, bgg_id: int) -> Dict[str, Any]:
     """Extract comprehensive game data from BGG XML response"""
     data = {}
     data["bgg_id"] = bgg_id
@@ -848,7 +849,7 @@ def _extract_comprehensive_game_data(item, bgg_id: int) -> Dict:
     return data
 
 
-def _get_game_classification(item) -> str:
+def _get_game_classification(item: Element) -> str:
     """
     Fallback game classification system based on categories and mechanics
     when BGG ranking data is not available

--- a/backend/middleware/logging.py
+++ b/backend/middleware/logging.py
@@ -18,7 +18,7 @@ class RequestLoggingMiddleware:
     def __init__(self, app: ASGIApp):
         self.app = app
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
@@ -39,7 +39,7 @@ class RequestLoggingMiddleware:
         )
 
         # Capture status code from response
-        async def send_wrapper(message):
+        async def send_wrapper(message: dict) -> None:
             nonlocal status_code
             if message["type"] == "http.response.start":
                 status_code = message.get("status", 200)

--- a/backend/middleware/performance.py
+++ b/backend/middleware/performance.py
@@ -5,6 +5,7 @@ Tracks request times, endpoint statistics, and slow queries.
 """
 import time
 from collections import deque, OrderedDict
+from typing import Dict, Any
 
 
 class PerformanceMonitor:
@@ -20,7 +21,7 @@ class PerformanceMonitor:
 
     def record_request(
         self, path: str, method: str, duration: float, status_code: int
-    ):
+    ) -> None:
         """Record request metrics with LRU eviction"""
         self.request_times.append(duration)
         endpoint_key = f"{method} {path}"
@@ -59,7 +60,7 @@ class PerformanceMonitor:
                 }
             )
 
-    def get_stats(self):
+    def get_stats(self) -> Dict[str, Any]:
         """Get performance statistics"""
         if not self.request_times:
             return {"message": "No requests recorded yet"}

--- a/backend/middleware/security.py
+++ b/backend/middleware/security.py
@@ -26,12 +26,12 @@ class SecurityHeadersMiddleware:
     def __init__(self, app: ASGIApp):
         self.app = app
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        async def send_wrapper(message):
+        async def send_wrapper(message: dict) -> None:
             if message["type"] == "http.response.start":
                 headers = dict(message.get("headers", []))
 

--- a/backend/services/image_service.py
+++ b/backend/services/image_service.py
@@ -49,7 +49,7 @@ class ImageService:
         )
         self._ensure_thumbs_dir()
 
-    def _ensure_thumbs_dir(self):
+    def _ensure_thumbs_dir(self) -> None:
         """Ensure thumbnails directory exists"""
         os.makedirs(THUMBS_DIR, exist_ok=True)
 

--- a/backend/shared/rate_limiting.py
+++ b/backend/shared/rate_limiting.py
@@ -9,7 +9,7 @@ Sprint 8: Migrated to Redis for horizontal scaling support.
 import json
 import logging
 from datetime import datetime
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Callable, Type
 from collections import defaultdict
 
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -30,12 +30,12 @@ def get_limiter() -> Limiter:
     return Limiter(key_func=get_remote_address, enabled=enabled)
 
 
-def get_rate_limit_exception_handler():
+def get_rate_limit_exception_handler() -> Callable:
     """Get the rate limit exception handler"""
     return _rate_limit_exceeded_handler
 
 
-def get_rate_limit_exception():
+def get_rate_limit_exception() -> Type[RateLimitExceeded]:
     """Get the rate limit exception class"""
     return RateLimitExceeded
 


### PR DESCRIPTION
Improved type safety and IDE support by adding missing type hints across backend modules:

- middleware/logging.py: Added return types to __call__ and send_wrapper methods
- middleware/performance.py: Added return types to record_request and get_stats, imported Dict/Any
- middleware/security.py: Added return types to __call__ and send_wrapper methods
- services/image_service.py: Added return type to _ensure_thumbs_dir method
- shared/rate_limiting.py: Added return types to utility functions (Callable, Type hints)
- bgg_service.py: Enhanced Dict return types to Dict[str, Any], added Element type hints to XML parsing functions

All changes maintain backward compatibility while improving code quality and developer experience.