### PR TITLE
Fix overlapping tab buttons on mobile admin

### DIFF
--- a/frontend/src/components/staff/TabNavigation.jsx
+++ b/frontend/src/components/staff/TabNavigation.jsx
@@ -8,15 +8,15 @@ import React from "react";
 export function TabNavigation({ activeTab, onTabChange, tabs }) {
   return (
     <div className="border-b border-gray-200 bg-white sticky top-16 z-30">
-      <nav className="max-w-7xl mx-auto px-4" aria-label="Admin navigation tabs">
-        <div className="flex gap-1 -mb-px overflow-x-auto">
+      <nav className="max-w-7xl mx-auto px-2 sm:px-4" aria-label="Admin navigation tabs">
+        <div className="flex gap-1 sm:gap-2 -mb-px overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent">
           {tabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => onTabChange(tab.id)}
               className={`
-                px-4 py-3 text-sm font-medium whitespace-nowrap
-                border-b-2 transition-colors duration-150
+                px-2 py-2 sm:px-4 sm:py-3 text-xs sm:text-sm font-medium whitespace-nowrap
+                border-b-2 transition-colors duration-150 flex-shrink-0
                 ${
                   activeTab === tab.id
                     ? "border-purple-600 text-purple-700 bg-purple-50"
@@ -25,9 +25,10 @@ export function TabNavigation({ activeTab, onTabChange, tabs }) {
               `}
               aria-current={activeTab === tab.id ? "page" : undefined}
             >
-              <span className="flex items-center gap-2">
-                {tab.icon && <span>{tab.icon}</span>}
-                {tab.label}
+              <span className="flex items-center gap-1 sm:gap-2">
+                {tab.icon && <span className="text-sm sm:text-base">{tab.icon}</span>}
+                <span className="hidden sm:inline">{tab.label}</span>
+                <span className="sm:hidden">{tab.label.split(" ")[0]}</span>
               </span>
             </button>
           ))}


### PR DESCRIPTION
Resolves issue where admin navigation tabs were overlapping on mobile devices by implementing responsive design improvements:

- Reduced button padding on mobile (px-2 py-2) while maintaining desktop padding (sm:px-4 sm:py-3)
- Decreased font size on mobile (text-xs) with normal size on desktop (sm:text-sm)
- Added flex-shrink-0 to prevent tabs from compressing and overlapping
- Implemented smart label truncation: show first word only on mobile (<640px), full labels on larger screens
- Responsive icon sizing (text-sm on mobile, sm:text-base on desktop)
- Responsive gaps between tabs and within tabs for better spacing
- Enhanced scrollbar styling for better horizontal scroll UX
- Reduced container padding on mobile for more space

The tabs now display cleanly on mobile devices without overlap while maintaining the full experience on desktop.