### PR TITLE
Debug game details page errors

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -194,7 +194,9 @@ async def get_public_game(
     """Get details for a specific game"""
     service = GameService(db)
     game = service.get_game_by_id(game_id)
-    if not game or game.status != "OWNED":
+    # Only show games that are owned (status is NULL or "OWNED")
+    # Hide games on buy list or wishlist
+    if not game or (game.status is not None and game.status != "OWNED"):
         raise GameNotFoundError("Game not found")
 
     # Build detailed response with expansions and base game info


### PR DESCRIPTION
The game details page was returning 404 errors because the status field is nullable in the database, but the code was only accepting games with status='OWNED'. Since many existing games have NULL status values, they were being incorrectly filtered out.

Changes:
- Updated public.py get_public_game() to treat NULL status as OWNED
- Updated game_service.py to include NULL status in all public queries:
  - get_all_games()
  - get_filtered_games()
  - get_games_by_designer()
  - get_category_counts()

This ensures backward compatibility with existing games while still hiding games that are explicitly marked as BUY_LIST or WISHLIST.