### PR TITLE
Fix autocomplete attribute on search input

### DIFF
--- a/frontend/src/components/public/SearchBox.jsx
+++ b/frontend/src/components/public/SearchBox.jsx
@@ -10,7 +10,7 @@ export default function SearchBox({ value, onChange, placeholder="Search games..
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
       aria-label={placeholder}
-      autoComplete="search"
+      autoComplete="off"
       spellCheck="false"
       role="searchbox"
       {...props}


### PR DESCRIPTION
The autocomplete attribute was using "search" which is not a valid HTML autocomplete token according to the HTML specification. For search inputs, autocomplete="off" is the appropriate value to disable browser autocomplete suggestions.

This fixes the HTML validation error in the SearchBox component.