### PR TITLE
Add complexity filtering and rating display

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -39,6 +39,8 @@ def _get_cached_games_key(
     designer: Optional[str],
     nz_designer: Optional[bool],
     players: Optional[int],
+    complexity_min: Optional[float],
+    complexity_max: Optional[float],
     recently_added: Optional[int],
     sort: str,
     page: int,
@@ -48,7 +50,7 @@ def _get_cached_games_key(
     from utils.cache import make_cache_key
     return make_cache_key(
         search, category, designer, nz_designer,
-        players, recently_added, sort, page, page_size
+        players, complexity_min, complexity_max, recently_added, sort, page, page_size
     )
 
 
@@ -59,6 +61,8 @@ def _get_games_from_db(
     designer: Optional[str],
     nz_designer: Optional[bool],
     players: Optional[int],
+    complexity_min: Optional[float],
+    complexity_max: Optional[float],
     recently_added: Optional[int],
     sort: str,
     page: int,
@@ -77,7 +81,7 @@ def _get_games_from_db(
     # Generate cache key
     cache_params = _get_cached_games_key(
         search, category, designer, nz_designer,
-        players, recently_added, sort, page, page_size
+        players, complexity_min, complexity_max, recently_added, sort, page, page_size
     )
     cache_key = f"games_query:{cache_params}"
 
@@ -95,6 +99,8 @@ def _get_games_from_db(
         designer=designer,
         nz_designer=nz_designer,
         players=players,
+        complexity_min=complexity_min,
+        complexity_max=complexity_max,
         recently_added_days=recently_added,
         sort=sort,
         page=page,
@@ -124,6 +130,12 @@ async def get_public_games(
     players: Optional[int] = Query(
         None, ge=1, description="Filter by player count"
     ),
+    complexity_min: Optional[float] = Query(
+        None, ge=1, le=5, description="Minimum complexity rating (1-5)"
+    ),
+    complexity_max: Optional[float] = Query(
+        None, ge=1, le=5, description="Maximum complexity rating (1-5)"
+    ),
     recently_added: Optional[int] = Query(
         None, ge=1, description="Filter games added within last N days"
     ),
@@ -146,6 +158,8 @@ async def get_public_games(
         designer=designer,
         nz_designer=nz_designer_bool,
         players=players,
+        complexity_min=complexity_min,
+        complexity_max=complexity_max,
         recently_added=recently_added,
         sort=sort,
         page=page,

--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -63,6 +63,8 @@ class GameService:
         designer: Optional[str] = None,
         nz_designer: Optional[bool] = None,
         players: Optional[int] = None,
+        complexity_min: Optional[float] = None,
+        complexity_max: Optional[float] = None,
         recently_added_days: Optional[int] = None,
         sort: str = "title_asc",
         page: int = 1,
@@ -77,6 +79,8 @@ class GameService:
             designer: Designer name filter
             nz_designer: Filter by NZ designer flag
             players: Filter by player count
+            complexity_min: Minimum complexity rating (1-5)
+            complexity_max: Maximum complexity rating (1-5)
             recently_added_days: Filter games added within last N days
             sort: Sort order
             page: Page number (1-indexed)
@@ -166,6 +170,23 @@ class GameService:
                     Game.id.in_(expansion_subquery),
                 )
             )
+
+        # Apply complexity filter
+        if complexity_min is not None or complexity_max is not None:
+            if complexity_min is not None:
+                query = query.where(
+                    and_(
+                        Game.complexity.isnot(None),
+                        Game.complexity >= complexity_min
+                    )
+                )
+            if complexity_max is not None:
+                query = query.where(
+                    and_(
+                        Game.complexity.isnot(None),
+                        Game.complexity <= complexity_max
+                    )
+                )
 
         # Apply recently added filter
         if recently_added_days is not None:

--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -246,6 +246,16 @@ export default function GameCardPublic({
               </svg>
               <span className="font-semibold">{formatTime()}</span>
             </div>
+
+            {/* Complexity - Icon with intuitive visual indicator */}
+            {formatComplexity(game.complexity) && (
+              <div className="flex items-center gap-1" aria-label={`Complexity: ${formatComplexity(game.complexity)} out of 5`}>
+                <svg className="w-4 h-4 text-amber-600" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+                <span className="font-semibold">{formatComplexity(game.complexity)}/5</span>
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Implemented comprehensive complexity filtering system similar to existing player count filtering, with intuitive UI on both mobile and desktop.

Backend changes:
- Added complexity_min and complexity_max parameters to game filtering API
- Updated GameService.get_filtered_games() to support complexity range filtering
- Updated cache key generation to include complexity parameters
- Added API validation for complexity values (1-5 range)

Frontend changes:
- Added complexity filter dropdown with intuitive ranges:
  * Light (1-1.5)
  * Light-Medium (1.5-2.5)
  * Medium (2.5-3.5)
  * Medium-Heavy (3.5-4.5)
  * Heavy (4.5-5)
- Integrated filter into both mobile and desktop filter panels
- Added complexity to URL state persistence
- Added complexity rating display on game cards with star icon
- Complexity shows in compact view alongside player count and playtime

The complexity rating is now prominently displayed on all game cards, helping users make informed decisions about game difficulty at a glance.