### PR TITLE
Replace expand arrow with clear 'Expand'/'Collapse' text

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -190,33 +190,21 @@ export default function GameCardPublic({
             <h3 className="font-bold text-base text-slate-800 line-clamp-2 leading-tight flex-1">
               {game.title}
             </h3>
-            <div className="relative flex-shrink-0">
-              <button
-                className={`p-1 rounded-full hover:bg-slate-100 ${transitionClass} focus:outline-none focus:ring-2 focus:ring-emerald-500 ${shouldShowCardHint && showHints ? 'animate-pulse' : ''}`}
-                aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleExpand();
-                }}
-              >
-                <svg
-                  className={`w-5 h-5 text-slate-600 ${transitionClass} ${isExpanded ? 'rotate-180' : ''}`}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
-              {/* Tap to expand hint - mobile only */}
-              {shouldShowCardHint && showHints && !isExpanded && (
-                <div className="absolute -bottom-6 right-0 md:hidden">
-                  <span className="text-[10px] text-emerald-700 font-semibold whitespace-nowrap bg-emerald-50 px-2 py-0.5 rounded-full border border-emerald-200 shadow-sm">
-                    Tap to expand
-                  </span>
-                </div>
-              )}
-            </div>
+            <button
+              className={`flex-shrink-0 px-2 py-1 rounded-md text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
+                isExpanded
+                  ? 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200'
+                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+              } ${shouldShowCardHint && showHints && !isExpanded ? 'animate-pulse ring-2 ring-emerald-500' : ''}`}
+              aria-label={isExpanded ? 'Collapse details' : 'Expand details'}
+              aria-expanded={isExpanded}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleExpand();
+              }}
+            >
+              {isExpanded ? 'Collapse' : 'Expand'}
+            </button>
           </div>
 
           {/* Compact Stats - Always Visible */}


### PR DESCRIPTION
Improves accessibility and usability by replacing the small arrow icon with clear text labels.

Changes:
- "Expand" button (gray) when card is collapsed
- "Collapse" button (emerald green) when card is expanded
- Pulse animation with emerald ring on first visit for new users
- Removed messy "Tap to expand" hint tooltip (no longer needed)
- Better accessibility - screen readers announce clear action text
- Larger touch target with visible text instead of small icon
- Color changes provide visual feedback of current state

This makes the interaction much more obvious, especially for:
- Screen reader users (clear button text)
- Mobile users (easier to understand and tap)
- First-time users (obvious what the button does)
- Color-coding shows state (gray = collapsed, green = expanded)