### PR TITLE
Fix single column layout for public view

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -111,16 +111,16 @@ export default function GameCardPublic({
     <article
       ref={cardRef}
       data-game-card
-      className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 ${isExpanded ? 'col-span-2 sm:col-span-1' : ''} flex flex-row md:flex-col`}
+      className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 flex flex-row`}
     >
 
       {/* Image Section - Always Visible */}
       <Link
         to={href}
-        className="block focus:outline-none flex-shrink-0 w-32 md:w-full"
+        className="block focus:outline-none flex-shrink-0 w-32 sm:w-40"
         aria-label={`View details for ${game.title}`}
       >
-        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 aspect-square h-full">
+        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 aspect-square">
           <GameImage
             url={imgSrc}
             alt={`Cover art for ${game.title}`}
@@ -168,7 +168,7 @@ export default function GameCardPublic({
       </Link>
 
       {/* Content Section - Collapsible */}
-      <div className="p-2 md:p-3 flex-1 flex flex-col">
+      <div className="p-3 sm:p-4 flex-1 flex flex-col">
 
         {/* Compact Info - Always Visible */}
         <div className="flex-1">

--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -856,7 +856,7 @@ export default function PublicCatalogue() {
           )}
 
           {loading && (
-            <div className="game-grid grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-6">
+            <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4">
               {/* Show skeleton loaders matching the grid layout */}
               {Array.from({ length: pageSize }).map((_, index) => (
                 <GameCardSkeleton key={`skeleton-${index}`} />
@@ -878,7 +878,7 @@ export default function PublicCatalogue() {
 
           {!loading && !error && allLoadedItems.length > 0 && (
             <>
-              <div className="game-grid grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-6">
+              <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4">
                 {allLoadedItems.map((game, index) => (
                   <GameCardPublic
                     key={game.id}
@@ -897,7 +897,7 @@ export default function PublicCatalogue() {
                 <>
                   {/* Show skeleton loaders while loading more to prevent scrollbar jumps */}
                   {loadingMore && (
-                    <div className="game-grid grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-6 mt-6">
+                    <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4 mt-6">
                       {Array.from({ length: Math.min(pageSize, total - allLoadedItems.length) }).map((_, index) => (
                         <GameCardSkeleton key={`loading-skeleton-${index}`} />
                       ))}


### PR DESCRIPTION
Changes:
- Changed grid from 2 columns to single column layout on all screen sizes
- Kept card layout as flex-row (image left, info right) on all devices
- Image maintains aspect-square with responsive width (w-32 sm:w-40)
- Removed desktop column layout (md:flex-col)
- Adjusted content padding for better spacing in row layout
- Updated all grid instances including loading skeletons

This fixes the issue where the previous attempt to change to single column didn't work because the md:flex-col was overriding on larger screens.