### PR TITLE
Fix image sizing to be exactly half row width on mobile

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -123,12 +123,12 @@ export default function GameCardPublic({
         to={href}
         className={`block focus:outline-none flex-shrink-0 ${
           isExpanded
-            ? 'w-full'
-            : 'w-[50vw] md:w-40'
+            ? 'w-full aspect-square'
+            : 'w-[50vw] h-full md:w-40 md:aspect-square'
         }`}
         aria-label={`View details for ${game.title}`}
       >
-        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 aspect-square h-full">
+        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
           <GameImage
             url={imgSrc}
             alt={`Cover art for ${game.title}`}


### PR DESCRIPTION
- Remove aspect-square conflict from image container
- Set explicit w-[50vw] h-full on Link to create perfect square
- Image now exactly half the card width on mobile as intended