### PR TITLE
Fix game card sizing on public view page

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -114,7 +114,7 @@ export default function GameCardPublic({
       className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 ${
         isExpanded
           ? 'flex flex-col'
-          : 'flex flex-row h-[50vw] md:h-auto'
+          : 'flex flex-row aspect-[2/1]'
       }`}
     >
 
@@ -124,7 +124,7 @@ export default function GameCardPublic({
         className={`block focus:outline-none flex-shrink-0 ${
           isExpanded
             ? 'w-full aspect-square'
-            : 'w-[50vw] h-full md:w-40 md:aspect-square'
+            : 'w-1/2 aspect-square'
         }`}
         aria-label={`View details for ${game.title}`}
       >


### PR DESCRIPTION
- Change minimized card to use aspect-[2/1] instead of viewport-based height
- Set image to w-1/2 aspect-square for exact half-width square sizing
- Ensures consistent card proportions across all screen sizes