### PR TITLE
Fix public catalogue card layout and sizing

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -124,7 +124,7 @@ export default function GameCardPublic({
         className={`block focus:outline-none flex-shrink-0 ${
           isExpanded
             ? 'w-full aspect-square'
-            : 'w-1/2 aspect-square'
+            : 'h-full aspect-square'
         }`}
         aria-label={`View details for ${game.title}`}
       >

--- a/frontend/src/components/public/GameCardSkeleton.jsx
+++ b/frontend/src/components/public/GameCardSkeleton.jsx
@@ -9,11 +9,11 @@ import React from "react";
 export default function GameCardSkeleton() {
   return (
     <article
-      className="game-card-container bg-white rounded-2xl overflow-hidden shadow-md border-2 border-slate-200 animate-pulse"
+      className="game-card-container bg-white rounded-2xl overflow-hidden shadow-md border-2 border-slate-200 animate-pulse flex flex-row aspect-[2/1]"
       aria-hidden="true"
     >
-      {/* Image Skeleton - Square aspect ratio */}
-      <div className="relative overflow-hidden bg-gradient-to-br from-slate-200 via-slate-100 to-slate-200 aspect-square">
+      {/* Image Skeleton - Square aspect ratio, matches GameCardPublic minimized state */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-slate-200 via-slate-100 to-slate-200 h-full aspect-square flex-shrink-0">
         <div className="w-full h-full flex items-center justify-center">
           <svg className="w-12 h-12 text-slate-300" fill="currentColor" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
@@ -22,17 +22,19 @@ export default function GameCardSkeleton() {
       </div>
 
       {/* Content Skeleton */}
-      <div className="p-3 space-y-3">
+      <div className="p-3 flex-1 flex flex-col">
         {/* Title Skeleton */}
-        <div className="space-y-2">
+        <div className="space-y-2 mb-3">
           <div className="h-4 bg-slate-200 rounded w-3/4"></div>
           <div className="h-4 bg-slate-200 rounded w-1/2"></div>
         </div>
 
-        {/* Stats Skeleton */}
-        <div className="flex items-center gap-3">
-          <div className="h-3 bg-slate-200 rounded w-12"></div>
-          <div className="h-3 bg-slate-200 rounded w-16"></div>
+        {/* Stats Grid Skeleton - 2x2 */}
+        <div className="grid grid-cols-2 gap-1.5 md:gap-2">
+          <div className="bg-slate-100 rounded-lg p-2 h-12"></div>
+          <div className="bg-slate-100 rounded-lg p-2 h-12"></div>
+          <div className="bg-slate-100 rounded-lg p-2 h-12"></div>
+          <div className="bg-slate-100 rounded-lg p-2 h-12"></div>
         </div>
       </div>
     </article>

--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -856,7 +856,7 @@ export default function PublicCatalogue() {
           )}
 
           {loading && (
-            <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4">
+            <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
               {/* Show skeleton loaders matching the grid layout */}
               {Array.from({ length: pageSize }).map((_, index) => (
                 <GameCardSkeleton key={`skeleton-${index}`} />
@@ -878,7 +878,7 @@ export default function PublicCatalogue() {
 
           {!loading && !error && allLoadedItems.length > 0 && (
             <>
-              <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4">
+              <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
                 {allLoadedItems.map((game, index) => (
                   <GameCardPublic
                     key={game.id}
@@ -897,7 +897,7 @@ export default function PublicCatalogue() {
                 <>
                   {/* Show skeleton loaders while loading more to prevent scrollbar jumps */}
                   {loadingMore && (
-                    <div className="game-grid grid grid-cols-1 gap-3 sm:gap-4 mt-6">
+                    <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 mt-6">
                       {Array.from({ length: Math.min(pageSize, total - allLoadedItems.length) }).map((_, index) => (
                         <GameCardSkeleton key={`loading-skeleton-${index}`} />
                       ))}


### PR DESCRIPTION
- Changed GameCardPublic minimized image from w-1/2 to h-full aspect-square for proper square image sizing within 2:1 card container
- Updated all grid layouts from single column to grid-cols-1 md:grid-cols-2 for 2-column layout on desktop, single column on mobile
- Updated GameCardSkeleton to match minimized card layout with flex-row and 2:1 aspect ratio for consistent loading states

This ensures cards display as 2:1 width-to-height ratio with square image on left and content on right, with responsive 2-column desktop layout.