### PR TITLE
Fix mobile card overflow by constraining width

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -111,7 +111,7 @@ export default function GameCardPublic({
     <article
       ref={cardRef}
       data-game-card
-      className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 ${
+      className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 w-full ${
         isExpanded
           ? 'flex flex-col'
           : 'flex flex-row aspect-[2/1]'

--- a/frontend/src/components/public/GameCardSkeleton.jsx
+++ b/frontend/src/components/public/GameCardSkeleton.jsx
@@ -9,7 +9,7 @@ import React from "react";
 export default function GameCardSkeleton() {
   return (
     <article
-      className="game-card-container bg-white rounded-2xl overflow-hidden shadow-md border-2 border-slate-200 animate-pulse flex flex-row aspect-[2/1]"
+      className="game-card-container bg-white rounded-2xl overflow-hidden shadow-md border-2 border-slate-200 animate-pulse flex flex-row aspect-[2/1] w-full"
       aria-hidden="true"
     >
       {/* Image Skeleton - Square aspect ratio, matches GameCardPublic minimized state */}


### PR DESCRIPTION
- Added w-full to GameCardPublic to ensure cards respect container width
- Added w-full to GameCardSkeleton to match
- Prevents cards from overflowing viewport on mobile devices

The aspect-[2/1] ratio is now properly constrained to the available width.