### PR TITLE
Fix public catalogue card layout and sizing

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -114,8 +114,9 @@ export default function GameCardPublic({
       className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 w-full ${
         isExpanded
           ? 'flex flex-col'
-          : 'flex flex-row aspect-[2/1]'
+          : 'flex flex-row h-auto'
       }`}
+      style={!isExpanded ? { aspectRatio: '2 / 1' } : {}}
     >
 
       {/* Image Section - Always Visible */}
@@ -124,11 +125,11 @@ export default function GameCardPublic({
         className={`block focus:outline-none flex-shrink-0 ${
           isExpanded
             ? 'w-full aspect-square'
-            : 'h-full aspect-square'
+            : 'w-1/2 h-full'
         }`}
         aria-label={`View details for ${game.title}`}
       >
-        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
+        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full" style={{ aspectRatio: '1 / 1' }}>
           <GameImage
             url={imgSrc}
             alt={`Cover art for ${game.title}`}
@@ -176,10 +177,10 @@ export default function GameCardPublic({
       </Link>
 
       {/* Content Section - Collapsible */}
-      <div className="p-3 sm:p-4 flex-1 flex flex-col">
+      <div className={`flex-1 flex flex-col ${isExpanded ? 'p-3 sm:p-4' : 'p-2 sm:p-3 overflow-hidden'}`}>
 
         {/* Compact Info - Always Visible */}
-        <div className="flex-1">
+        <div className="flex-1 min-h-0">
           {/* Title - Full width without expand button */}
           <h3 className="font-bold text-sm md:text-base text-slate-800 line-clamp-2 leading-tight mb-1.5 md:mb-2">
             {game.title}


### PR DESCRIPTION
- Use inline style for aspect ratio to ensure strict enforcement
- Set image width to 50% (w-1/2) when minimized to match 2:1 card ratio
- Add explicit 1:1 aspect ratio to image container
- Reduce padding on minimized cards to fit content better
- Add overflow-hidden and min-h-0 to prevent content from breaking aspect ratio

This ensures cards maintain 2:1 ratio on both mobile (1 column) and desktop (2 columns), with the image always being a perfect square on the left taking exactly half the card width.