### PR TITLE
Use padding-bottom hack for bulletproof 2:1 aspect ratio

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -112,24 +112,19 @@ export default function GameCardPublic({
       ref={cardRef}
       data-game-card
       className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 w-full ${
-        isExpanded
-          ? 'flex flex-col'
-          : 'grid aspect-[2/1]'
+        isExpanded ? 'flex flex-col' : 'relative'
       }`}
-      style={!isExpanded ? { gridTemplateColumns: '1fr 1fr' } : {}}
+      style={!isExpanded ? { paddingBottom: '50%' } : {}}
     >
-
-      {/* Image Section - Always Visible */}
-      <Link
-        to={href}
-        className={`block focus:outline-none ${
-          isExpanded
-            ? 'w-full aspect-square'
-            : 'h-full w-full'
-        }`}
-        aria-label={`View details for ${game.title}`}
-      >
-        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
+      {!isExpanded && (
+        <div className="absolute inset-0 flex flex-row">
+          {/* Image Section - Minimized */}
+          <Link
+            to={href}
+            className="block focus:outline-none w-1/2 h-full"
+            aria-label={`View details for ${game.title}`}
+          >
+            <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
           <GameImage
             url={imgSrc}
             alt={`Cover art for ${game.title}`}
@@ -176,8 +171,8 @@ export default function GameCardPublic({
         </div>
       </Link>
 
-      {/* Content Section - Collapsible */}
-      <div className={`flex flex-col min-w-0 ${isExpanded ? 'p-3 sm:p-4' : 'p-2 sm:p-3 h-full overflow-hidden'}`}>
+      {/* Content Section - Minimized */}
+      <div className="w-1/2 h-full flex flex-col p-2 sm:p-3 overflow-hidden min-w-0">
 
         {/* Compact Info - Always Visible */}
         <div className="flex-1">
@@ -402,6 +397,276 @@ export default function GameCardPublic({
           </div>
         </div>
       </div>
+    </div>
+  )}
+
+  {/* Expanded State */}
+  {isExpanded && (
+    <>
+      {/* Image Section - Expanded */}
+      <Link
+        to={href}
+        className="block focus:outline-none w-full aspect-square"
+        aria-label={`View details for ${game.title}`}
+      >
+        <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
+          <GameImage
+            url={imgSrc}
+            alt={`Cover art for ${game.title}`}
+            className={`w-full h-full object-cover ${transitionClass} group-hover:scale-110`}
+            fallbackClass="w-full h-full flex flex-col items-center justify-center text-slate-500 bg-gradient-to-br from-slate-100 to-slate-200"
+            loading={lazy ? "lazy" : "eager"}
+            fetchPriority={priority ? "high" : "auto"}
+            aspectRatio="1/1"
+          />
+
+          {/* Category Badge */}
+          {categoryLabel && (
+            <div className="absolute top-2 right-2">
+              <span
+                className={`px-2 py-1 rounded-lg text-xs font-bold shadow-lg border-2 backdrop-blur-sm ${getCategoryStyle(game.mana_meeple_category)}`}
+                aria-label={`Category: ${categoryLabel}`}
+              >
+                {categoryLabel}
+              </span>
+            </div>
+          )}
+
+          {/* Expansion Badge */}
+          {game.is_expansion && (
+            <div className="absolute top-2 left-2">
+              <span
+                className={`px-2 py-1 rounded-lg text-xs font-bold shadow-lg border-2 backdrop-blur-sm ${
+                  game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                    ? 'bg-indigo-700 text-white border-indigo-800'
+                    : 'bg-purple-700 text-white border-purple-800'
+                }`}
+                aria-label={
+                  game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                    ? 'Standalone Expansion'
+                    : 'Expansion'
+                }
+              >
+                {game.expansion_type === 'both' || game.expansion_type === 'standalone'
+                  ? 'STANDALONE'
+                  : 'EXPANSION'}
+              </span>
+            </div>
+          )}
+        </div>
+      </Link>
+
+      {/* Content Section - Expanded */}
+      <div className="p-3 sm:p-4 flex flex-col">
+        {/* Title */}
+        <h3 className="font-bold text-sm md:text-base text-slate-800 line-clamp-2 leading-tight mb-1.5 md:mb-2">
+          {game.title}
+        </h3>
+
+        {/* 2x2 Grid: Stats + Expand Button */}
+        <div className="grid grid-cols-2 gap-1.5 md:gap-2 mb-3">
+          {/* Players */}
+          {(() => {
+            const playerCount = formatPlayerCount();
+
+            return (
+              <div
+                className="flex flex-col items-center justify-center gap-0.5 md:gap-1 bg-slate-50 rounded-lg py-1.5 md:py-2 px-1"
+                aria-label={playerCount ? `${playerCount} players` : 'Player count not available'}
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4 text-emerald-600" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3z"/>
+                </svg>
+                <span className="font-semibold text-xs md:text-sm text-slate-700">
+                  {playerCount || '—'}
+                </span>
+              </div>
+            );
+          })()}
+
+          {/* Time */}
+          <div
+            className="flex flex-col items-center justify-center gap-0.5 md:gap-1 bg-slate-50 rounded-lg py-1.5 md:py-2 px-1"
+            aria-label={`Play time: ${formatTime()}`}
+          >
+            <svg className="w-3.5 h-3.5 md:w-4 md:h-4 text-slate-500" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
+            </svg>
+            <span className="font-semibold text-xs md:text-sm text-slate-700">
+              {formatTime()}
+            </span>
+          </div>
+
+          {/* Complexity */}
+          {formatComplexity(game.complexity) ? (
+            <div
+              className="flex flex-col items-center justify-center gap-0.5 bg-slate-50 rounded-lg py-1.5 md:py-2 px-1"
+              aria-label={`Complexity: ${formatComplexity(game.complexity)} out of 5`}
+            >
+              <span className="text-[9px] md:text-[10px] font-bold text-amber-600 uppercase tracking-wide">Complex</span>
+              <span className="font-semibold text-xs md:text-sm text-slate-700">
+                {formatComplexity(game.complexity)}/5
+              </span>
+            </div>
+          ) : (
+            <div
+              className="flex flex-col items-center justify-center gap-0.5 bg-slate-50 rounded-lg py-1.5 md:py-2 px-1"
+              aria-label="Complexity not available"
+            >
+              <span className="text-[9px] md:text-[10px] font-bold text-slate-400 uppercase tracking-wide">Complex</span>
+              <span className="font-semibold text-xs md:text-sm text-slate-400">—</span>
+            </div>
+          )}
+
+          {/* Expand Button */}
+          <button
+            className="flex flex-col items-center justify-center gap-0.5 md:gap-1 rounded-lg py-1.5 md:py-2 px-1 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 bg-emerald-100 text-emerald-700 hover:bg-emerald-200"
+            aria-label="Collapse details"
+            aria-expanded={true}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleExpand();
+            }}
+          >
+            <svg
+              className="w-3.5 h-3.5 md:w-4 md:h-4 transition-transform rotate-180"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+            <span className="text-[10px] md:text-xs">Less</span>
+          </button>
+        </div>
+
+        {/* Expanded Details - directly visible when expanded */}
+        <div className="pt-3 border-t border-slate-200 space-y-2 text-sm">
+          {/* Players - Full text */}
+          {(() => {
+            const playerCount = formatPlayerCount();
+            if (!playerCount) return null;
+
+            return (
+              <div className="flex items-center gap-2">
+                <span className="text-slate-700">
+                  <span className="font-semibold">Players:</span> {playerCount}
+                </span>
+              </div>
+            );
+          })()}
+
+          {/* Time - Full text */}
+          <div className="flex items-center gap-2">
+            <span className="text-slate-700">
+              <span className="font-semibold">Play Time:</span> {formatTime()}
+            </span>
+          </div>
+
+          {/* Rating */}
+          {formatRating(game.average_rating) && (
+            <div className="flex items-center gap-2">
+              <span className="text-slate-700">
+                <span className="font-semibold">BGG Rating:</span> {formatRating(game.average_rating)}/10
+              </span>
+            </div>
+          )}
+
+          {/* Complexity */}
+          {formatComplexity(game.complexity) && (
+            <div className="flex items-center gap-2">
+              <span className="text-slate-700">
+                <span className="font-semibold">Complexity:</span> {formatComplexity(game.complexity)}/5
+              </span>
+            </div>
+          )}
+
+          {/* Designers */}
+          {game.designers && game.designers.length > 0 && (
+            <div className="flex items-start gap-2">
+              <span className="text-slate-700">
+                <span className="font-semibold">Designer{game.designers.length > 1 ? 's' : ''}:</span>{' '}
+                {game.designers.slice(0, 2).join(', ')}
+                {game.designers.length > 2 && ` +${game.designers.length - 2} more`}
+              </span>
+            </div>
+          )}
+
+          {/* Year */}
+          {game.year && (
+            <div className="flex items-center gap-2">
+              <span className="text-slate-700">
+                <span className="font-semibold">Published:</span> {game.year}
+              </span>
+            </div>
+          )}
+
+          {/* NZ Designer Badge */}
+          {game.nz_designer && (
+            <div className="flex items-center gap-2 bg-blue-50 border border-blue-200 rounded-lg px-2 py-1.5">
+              <span className="text-lg" aria-hidden="true">🇳🇿</span>
+              <span className="text-blue-900 font-semibold text-xs">New Zealand Designer</span>
+            </div>
+          )}
+
+          {/* Description Preview */}
+          {game.description && (
+            <div className="pt-2">
+              <p className="text-slate-600 text-xs line-clamp-3 leading-relaxed">
+                {game.description}
+              </p>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex flex-wrap gap-2 mt-3">
+            {/* Plan a Game Button */}
+            <div className="relative">
+              <a
+                href={getAfterGameCreateUrl(game.aftergame_game_id)}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => markAfterGameClicked()}
+                className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-gradient-to-r from-teal-500 to-emerald-500 text-white font-semibold text-sm hover:from-teal-600 hover:to-emerald-600 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2"
+                aria-label="Plan a game session on AfterGame"
+                title={shouldShowAfterGameHint ? "Schedule a game session with the Mana & Meeples community" : undefined}
+              >
+                <img
+                  src="/Aftergame_Icon_Logo_V3-Light.webp"
+                  alt="AfterGame"
+                  className="w-5 h-5"
+                />
+                <span>Plan a Game</span>
+              </a>
+              {/* AfterGame hint tooltip - mobile only */}
+              {shouldShowAfterGameHint && showHints && (
+                <div className="absolute -top-12 left-0 right-0 md:hidden pointer-events-none z-10">
+                  <div className="bg-teal-700 text-white text-xs px-3 py-2 rounded-lg shadow-lg text-center">
+                    Schedule a session!
+                    <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-full">
+                      <div className="border-8 border-transparent border-t-teal-700"></div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* View Full Details Link */}
+            <Link
+              to={href}
+              className="inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-semibold text-sm px-2 py-2 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 rounded"
+            >
+              <span>View Full Details</span>
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </>
+  )}
     </article>
   );
 }


### PR DESCRIPTION
Problem: aspect-ratio CSS property unreliable with flex/grid children
Solution: Classic padding-bottom percentage trick (always works)

Changes:
- Card wrapper: padding-bottom: 50% creates 2:1 ratio (50% of width)
- Absolute positioning: flex container inside fills the ratio box
- Left column (image): w-1/2 h-full - exactly 50% width, full height
- Right column (content): w-1/2 h-full - exactly 50% width, full height
- Separate minimized/expanded states for cleaner code

The padding-bottom technique is browser-proof and cannot be overridden by content. Image column is automatically square (50% of card width for both width and height).