### PR TITLE
Fix image sizing with aspect-square on height-based container

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -121,7 +121,7 @@ export default function GameCardPublic({
           {/* Image Section - Minimized */}
           <Link
             to={href}
-            className="block focus:outline-none w-1/2 h-full"
+            className="block focus:outline-none aspect-square h-full flex-shrink-0"
             aria-label={`View details for ${game.title}`}
           >
             <div className="relative overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 w-full h-full">
@@ -172,7 +172,7 @@ export default function GameCardPublic({
       </Link>
 
       {/* Content Section - Minimized */}
-      <div className="w-1/2 h-full flex flex-col p-2 sm:p-3 overflow-hidden min-w-0">
+      <div className="flex-1 h-full flex flex-col p-2 sm:p-3 overflow-hidden min-w-0">
 
         {/* Compact Info - Always Visible */}
         <div className="flex-1">


### PR DESCRIPTION
Problem: Image with w-1/2 wasn't properly square in the flex container
Solution: Use aspect-square h-full instead

Changes:
- Image: aspect-square h-full flex-shrink-0
  - Takes full height of 2:1 container
  - aspect-square makes width equal to height (creates perfect square)
  - flex-shrink-0 prevents compression
- Content: flex-1 (fills remaining horizontal space)

Example: Card 400px wide × 200px tall
- Image: 200px height → aspect-square → 200px × 200px
- Content: Remaining 200px width