### PR TITLE
Separate aspect ratio container from flex layout container

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -112,11 +112,11 @@ export default function GameCardPublic({
       ref={cardRef}
       data-game-card
       className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 w-full ${
-        isExpanded ? 'flex flex-col' : 'flex flex-row aspect-[2/1]'
+        isExpanded ? 'flex flex-col' : 'aspect-[2/1]'
       }`}
     >
       {!isExpanded && (
-        <>
+        <div className="flex flex-row w-full h-full">
           {/* Image Section - Minimized */}
           <Link
             to={href}
@@ -396,7 +396,7 @@ export default function GameCardPublic({
           </div>
         </div>
       </div>
-        </>
+        </div>
       )}
 
   {/* Expanded State */}


### PR DESCRIPTION
Problem: aspect-[2/1] on flex container was being overridden by flex children
Solution: aspect-[2/1] on article, flex layout on inner wrapper div

Structure:
- Article: aspect-[2/1] (enforces 2:1 ratio, NO flex)
- Inner wrapper: flex flex-row w-full h-full (layout fills aspect ratio box)
- Image: w-1/2 h-full (50% of wrapper)
- Content: w-1/2 h-full (50% of wrapper)

This prevents flex children from pushing the height beyond the aspect ratio constraint. The aspect ratio is enforced at the outer level first, then flex layout happens inside.