### PR TITLE
Use inline styles for aspect ratio with maximum specificity

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -112,11 +112,12 @@ export default function GameCardPublic({
       ref={cardRef}
       data-game-card
       className={`game-card-container scroll-mt-24 group bg-white rounded-2xl overflow-hidden shadow-md hover:shadow-xl border-2 border-slate-200 ${transitionClass} hover:border-emerald-300 focus-within:ring-4 focus-within:ring-emerald-200 focus-within:ring-offset-2 w-full ${
-        isExpanded ? 'flex flex-col' : 'aspect-[2/1]'
+        isExpanded ? 'flex flex-col' : ''
       }`}
+      style={!isExpanded ? { aspectRatio: '2 / 1', display: 'block' } : {}}
     >
       {!isExpanded && (
-        <div className="flex flex-row w-full h-full">
+        <div className="flex flex-row w-full h-full" style={{ maxHeight: '100%' }}>
           {/* Image Section - Minimized */}
           <Link
             to={href}


### PR DESCRIPTION
Problem: Tailwind aspect-[2/1] class may be overridden by other CSS
Solution: Use inline style with aspectRatio property

Changes:
- Replace aspect-[2/1] class with style={{ aspectRatio: '2 / 1' }}
- Force display: block to prevent flex/grid conflicts
- Add maxHeight: 100% to inner flex container to prevent overflow

Inline styles have maximum CSS specificity and cannot be overridden by classes. This ensures the 2:1 ratio is strictly enforced regardless of other CSS.