### PR TITLE
Remove conflicting aspectRatio prop from GameImage component

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -138,7 +138,6 @@ export default function GameCardPublic({
             fallbackClass="w-full h-full flex flex-col items-center justify-center text-slate-500 bg-gradient-to-br from-slate-100 to-slate-200"
             loading={lazy ? "lazy" : "eager"}
             fetchPriority={priority ? "high" : "auto"}
-            aspectRatio="1/1"
           />
           
           {/* Category Badge */}
@@ -424,7 +423,6 @@ export default function GameCardPublic({
             fallbackClass="w-full h-full flex flex-col items-center justify-center text-slate-500 bg-gradient-to-br from-slate-100 to-slate-200"
             loading={lazy ? "lazy" : "eager"}
             fetchPriority={priority ? "high" : "auto"}
-            aspectRatio="1/1"
           />
 
           {/* Category Badge */}


### PR DESCRIPTION
CRITICAL FIX: The GameImage component was adding aspect-ratio: 1/1 to its wrapper div, which was conflicting with w-full h-full from the parent.

Problem:
- Parent container: width 50%, height 100% (of 2:1 card)
- GameImage wrapper: w-full h-full + aspect-ratio: 1/1
- These constraints fight each other, breaking the layout

Solution:
- Remove aspectRatio="1/1" prop from GameImage
- Let the image naturally fill its parent container
- Parent already has correct dimensions from card's 2:1 ratio

The image will now properly fill the 50% width column which is already square.