### PR TITLE
Fix card layout by overriding GameImage default aspectRatio

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -138,6 +138,7 @@ export default function GameCardPublic({
             fallbackClass="w-full h-full flex flex-col items-center justify-center text-slate-500 bg-gradient-to-br from-slate-100 to-slate-200"
             loading={lazy ? "lazy" : "eager"}
             fetchPriority={priority ? "high" : "auto"}
+            aspectRatio=""
           />
           
           {/* Category Badge */}
@@ -423,6 +424,7 @@ export default function GameCardPublic({
             fallbackClass="w-full h-full flex flex-col items-center justify-center text-slate-500 bg-gradient-to-br from-slate-100 to-slate-200"
             loading={lazy ? "lazy" : "eager"}
             fetchPriority={priority ? "high" : "auto"}
+            aspectRatio=""
           />
 
           {/* Category Badge */}


### PR DESCRIPTION
The GameImage component has a default prop aspectRatio="1/1" that was conflicting with the parent container's size constraints in minimized card view. The parent manages sizing (50% width, 100% height of 2:1 card = square), so GameImage should not apply its own aspect ratio.

This fix passes aspectRatio="" to override the default in both minimized and expanded states, preventing the conflicting inline style from being added.