### PR TITLE
Add items-start to grids to prevent card vertical stretching

### DIFF
--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -856,7 +856,7 @@ export default function PublicCatalogue() {
           )}
 
           {loading && (
-            <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
+            <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 items-start">
               {/* Show skeleton loaders matching the grid layout */}
               {Array.from({ length: pageSize }).map((_, index) => (
                 <GameCardSkeleton key={`skeleton-${index}`} />
@@ -878,7 +878,7 @@ export default function PublicCatalogue() {
 
           {!loading && !error && allLoadedItems.length > 0 && (
             <>
-              <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
+              <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 items-start">
                 {allLoadedItems.map((game, index) => (
                   <GameCardPublic
                     key={game.id}
@@ -897,7 +897,7 @@ export default function PublicCatalogue() {
                 <>
                   {/* Show skeleton loaders while loading more to prevent scrollbar jumps */}
                   {loadingMore && (
-                    <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 mt-6">
+                    <div className="game-grid grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 items-start mt-6">
                       {Array.from({ length: Math.min(pageSize, total - allLoadedItems.length) }).map((_, index) => (
                         <GameCardSkeleton key={`loading-skeleton-${index}`} />
                       ))}


### PR DESCRIPTION
CSS Grid's default align-items: stretch was causing cards to stretch vertically to fill row height. Added items-start to all three grid containers (main, loading, loading-more) to ensure cards maintain their intrinsic 2:1 aspect ratio without being stretched.