### PR TITLE
Remove conflicting min-height from game-card-container

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -202,8 +202,6 @@ a:not([role="button"]):not(.btn) {
 
 /* Prevent layout shifts during image and content loading */
 .game-card-container {
-  /* Reserve minimum height to prevent CLS */
-  min-height: 300px;
   /* Ensure consistent sizing */
   contain: layout;
 }


### PR DESCRIPTION
The min-height: 300px was preventing the aspect-[2/1] from working correctly, forcing cards to be too tall. Removed the min-height while keeping contain: layout for performance.