### PR TITLE
fix: Correct timestamp format in helper functions

### DIFF
--- a/backend/utils/helpers.py
+++ b/backend/utils/helpers.py
@@ -464,7 +464,7 @@ def success_response(
     response = {
         "success": True,
         "message": message,
-        "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
     }
     if data is not None:
         response["data"] = data
@@ -495,7 +495,7 @@ def error_response(
     response = {
         "success": False,
         "error": {"code": error_code, "message": message},
-        "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
     }
     if details is not None:
         response["error"]["details"] = details


### PR DESCRIPTION
The timezone-aware datetime.now(timezone.utc).isoformat() already includes '+00:00' timezone indicator, so we need to replace it with 'Z' instead of appending 'Z' to avoid double timezone indicators.

This fixes the test failures in:
- test_success_response_timestamp_format
- test_error_response_timestamp_format