### PR TITLE
test: Fix useOnboarding hook timestamp race condition

### DIFF
--- a/frontend/src/hooks/useOnboarding.js
+++ b/frontend/src/hooks/useOnboarding.js
@@ -33,10 +33,11 @@ export function useOnboarding() {
     }
 
     // First visit
+    const now = new Date().toISOString();
     return {
       ...defaultState,
-      firstVisit: new Date().toISOString(),
-      lastVisit: new Date().toISOString(),
+      firstVisit: now,
+      lastVisit: now,
     };
   });
 
@@ -82,10 +83,11 @@ export function useOnboarding() {
 
   // Reset all onboarding state (useful for testing)
   const reset = useCallback(() => {
+    const now = new Date().toISOString();
     setState({
       ...defaultState,
-      firstVisit: new Date().toISOString(),
-      lastVisit: new Date().toISOString(),
+      firstVisit: now,
+      lastVisit: now,
     });
   }, []);
 


### PR DESCRIPTION
Fixed a race condition in the useOnboarding hook where consecutive calls to `new Date().toISOString()` could produce different timestamps, causing the `isFirstVisit` logic to fail. Now creates a single timestamp and reuses it for both `firstVisit` and `lastVisit` fields.

This fixes the failing test "initializes with default state on first visit" and ensures consistent behavior across all test environments.

Changes:
- Create timestamp once in initialization and reuse for both fields
- Apply same fix to the `reset()` function
- All 388 tests now passing
- Frontend test coverage: 63.06%