### PR TITLE
Fix missing admin token configuration warning

### DIFF
--- a/.github/workflows/fetch-buy-list-prices.yml
+++ b/.github/workflows/fetch-buy-list-prices.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cd backend
           pip install --upgrade pip
-          pip install playwright beautifulsoup4 lxml pandas python-dateutil psycopg2-binary sqlalchemy python-dotenv
+          pip install alembic playwright beautifulsoup4 lxml pandas python-dateutil psycopg2-binary sqlalchemy python-dotenv
 
       - name: Install Playwright browsers
         run: |
@@ -52,6 +52,7 @@ jobs:
       - name: Run database migrations
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SKIP_ADMIN_WARNING: 'true'
         run: |
           cd backend
           python scripts/run_migrations.py
@@ -59,6 +60,7 @@ jobs:
       - name: Export buy list from database
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SKIP_ADMIN_WARNING: 'true'
         run: |
           cd backend
           python scripts/export_buy_list.py

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,9 @@ CORS_ORIGINS = [
 
 # Admin token for protected endpoints
 ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "")
-if not ADMIN_TOKEN:
+# Only warn about missing ADMIN_TOKEN if not in CI/CD environment
+# and not in a migration-only context
+if not ADMIN_TOKEN and not os.getenv("CI") and os.getenv("SKIP_ADMIN_WARNING", "").lower() != "true":
     print(
         "WARNING: ADMIN_TOKEN not set - admin endpoints will be unavailable",
         file=sys.stderr,


### PR DESCRIPTION
- Add alembic to workflow dependencies to fix migration failures
- Make ADMIN_TOKEN warning context-aware (suppressed in CI/CD)
- Add SKIP_ADMIN_WARNING env var to migration and export steps

This fixes the "Alembic is not installed!" error in the fetch-buy-list-prices workflow and reduces noise from warnings in CI/CD contexts where admin endpoints are not needed.