### PR TITLE
Fix front page logo error

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -61,7 +61,7 @@ export const API_BASE = resolveApiBase().replace(/\/+$/, "");
  * Set to null or empty string to use legacy (unversioned) endpoints
  * @type {string}
  */
-export const API_VERSION = "v1";
+export const API_VERSION = null;
 
 /**
  * Get versioned API endpoint URL


### PR DESCRIPTION
The frontend was configured to use API_VERSION = 'v1', which caused requests to be sent to /api/v1/public/category-counts. However, the backend's versioned endpoint structure would create a double prefix (/api/v1/api/public/...) which doesn't exist.

The correct endpoint is /api/public/category-counts (unversioned). This fix disables API versioning to use the working legacy endpoints.