### PR TITLE
Fix API calls freezing during price import

### DIFF
--- a/frontend/src/components/staff/tabs/BuyListTab.jsx
+++ b/frontend/src/components/staff/tabs/BuyListTab.jsx
@@ -84,15 +84,31 @@ export function BuyListTab() {
     try {
       setError(null);
       setSuccess(null);
+      setLoading(true);
+
+      // Show immediate feedback that import is starting
+      setSuccess("⏳ Import started... This may take several minutes for large datasets. Please wait...");
+
       const result = await importPrices("latest_prices.json");
-      setSuccess(
-        `Imported ${result.imported} prices, skipped ${result.skipped}`
-      );
+
+      // Show detailed results
+      const message = `✅ Import completed! ${result.imported} prices imported, ${result.skipped} skipped${result.total ? ` (out of ${result.total} total)` : ''}`;
+      setSuccess(message);
+
+      // Reload data
       await loadBuyList();
       await loadLastUpdate();
     } catch (err) {
       console.error("Failed to import prices:", err);
-      setError("Failed to import prices");
+
+      // Provide helpful error message
+      if (err.message?.includes('timeout')) {
+        setError("⚠️ Import timed out (>5 min). The operation may still be processing. Please refresh in a moment and check if prices were updated.");
+      } else {
+        setError(`Failed to import prices: ${err.response?.data?.detail || err.message || 'Unknown error'}`);
+      }
+    } finally {
+      setLoading(false);
     }
   };
 


### PR DESCRIPTION
Root causes identified and fixed:
1. No axios timeout - requests could hang indefinitely
2. Backend processing large datasets synchronously without batching
3. Single large database transaction causing blocking
4. No user feedback during long operations

Changes:
- Add 5-minute timeout to axios instance for all API calls
- Implement batch processing (50 games per commit) in price import
- Add progress logging every batch for monitoring
- Improve error handling with specific timeout detection
- Add user-friendly feedback messages during import
- Show immediate "Import started" message to user
- Display detailed completion statistics (imported/skipped/total)

This fixes the issue where importing 4,475+ lines of price data would freeze the UI and require multiple refreshes.