### PR TITLE
fix: wrap IntersectionObserver test assertion in waitFor

### DIFF
--- a/frontend/src/pages/__tests__/PublicCatalogue.test.jsx
+++ b/frontend/src/pages/__tests__/PublicCatalogue.test.jsx
@@ -207,8 +207,10 @@ describe('PublicCatalogue Page', () => {
       expect(screen.getByText('Game 1')).toBeInTheDocument();
     });
 
-    // Verify IntersectionObserver was created
-    expect(global.IntersectionObserver).toHaveBeenCalled();
+    // Verify IntersectionObserver was created (wait for useEffect to complete)
+    await waitFor(() => {
+      expect(global.IntersectionObserver).toHaveBeenCalled();
+    });
   });
 
   test('displays load more indicator when more pages available', async () => {


### PR DESCRIPTION
The test was failing because it checked for IntersectionObserver being called before the useEffect hook had time to complete. By wrapping the assertion in waitFor, we give the async setup time to complete.

This resolves the race condition between React's rendering lifecycle and the test expectations, ensuring the IntersectionObserver is properly instantiated before we assert on it.