### PR TITLE
fix: update API base URL to correct backend service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ BGG_API_KEY=your-bgg-api-key-here
 CORS_ORIGINS=https://manaandmeeples.co.nz,https://www.manaandmeeples.co.nz
 
 # Public API Base URL
-PUBLIC_BASE_URL=https://mana-meeples-boardgame-list-opgf.onrender.com
+PUBLIC_BASE_URL=https://mana-meeples-boardgame-list.onrender.com
 
 # Cloudinary CDN Configuration
 # Sign up at https://cloudinary.com for free account

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
     <!-- API Configuration -->
-    <meta name="api-base" content="https://mana-meeples-boardgame-list-opgf.onrender.com" />
+    <meta name="api-base" content="https://mana-meeples-boardgame-list.onrender.com" />
 
     <title>Mana & Meeples Library</title>
   </head>


### PR DESCRIPTION
The frontend was calling the wrong backend URL due to a hardcoded meta tag pointing to an old deployment. This caused CORS errors because the requests were going to a different service.

Changed:
- frontend/index.html: Updated api-base meta tag from mana-meeples-boardgame-list-opgf.onrender.com to mana-meeples-boardgame-list.onrender.com
- .env.example: Updated PUBLIC_BASE_URL to match

The correct backend URL is already configured in render.yaml, so no other changes needed. This ensures the frontend calls the backend where we just fixed the CORS issue.