### PR TITLE
Fix service worker cache reference error

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -328,7 +328,7 @@ async function cacheFirstStrategy(request, cacheName) {
 
   if (cachedResponse) {
     // Check if cache is still fresh for images
-    if (cacheName === CACHES.IMAGES) {
+    if (cacheName.includes('-images')) {
       if (isCacheFresh(cachedResponse, CACHE_DURATION.IMAGES)) {
         return cachedResponse;
       }


### PR DESCRIPTION
Replace incorrect CACHES.IMAGES reference with cacheName.includes('-images') to properly check image cache freshness. The CACHES constant was never defined, causing ReferenceError that prevented service worker from functioning.

Fixes network error on library.manaandmeeples.co.nz