### PR TITLE
fix: use explicit headers in CORS config when credentials enabled

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -470,13 +470,32 @@ app.add_middleware(SecurityHeadersMiddleware)
 
 # CORS middleware MUST be added last to wrap all other middleware
 # This ensures preflight OPTIONS requests are handled correctly
+# NOTE: When allow_credentials=True, we must use explicit headers (not wildcards)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],  # Allow all methods
-    allow_headers=["*"],  # Allow all headers
-    expose_headers=["*"],  # Expose all headers
+    allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+    allow_headers=[
+        "content-type",
+        "authorization",
+        "accept",
+        "origin",
+        "user-agent",
+        "dnt",
+        "cache-control",
+        "x-requested-with",
+        "x-admin-token",
+        "accept-language",
+        "accept-encoding",
+    ],
+    expose_headers=[
+        "content-length",
+        "content-type",
+        "x-total-count",
+        "access-control-allow-origin",
+        "access-control-allow-credentials",
+    ],
     max_age=3600,  # Cache preflight requests for 1 hour
 )
 logger.info("CORS middleware configured and added to application")


### PR DESCRIPTION
Changed CORS middleware configuration to use explicit header lists instead of wildcards when allow_credentials=True. The CORS specification requires explicit headers when credentials are enabled - wildcards cause preflight requests to fail.

Changes:
- Changed allow_methods from ["*"] to explicit list
- Changed allow_headers from ["*"] to explicit common headers
- Changed expose_headers from ["*"] to explicit response headers
- Added comprehensive list of common request headers
- Included necessary headers for frontend API requests

This fixes the "No 'Access-Control-Allow-Origin' header" error on preflight OPTIONS requests from the frontend.

Technical details:
When allow_credentials=True, CORS spec requires:
- Explicit origin list (already correct)
- Explicit allow_headers list (was using wildcard)
- Explicit expose_headers list (was using wildcard)

Wildcard headers with credentials cause browsers to reject preflight responses.