### PR TITLE
fix: update backend URL to match new Render service URL

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -56,7 +56,7 @@ PUBLIC_BASE_URL = os.getenv("PUBLIC_BASE_URL", "").rstrip("/")
 
 # API base URL for image proxying and absolute URLs
 API_BASE = (
-    PUBLIC_BASE_URL or "https://mana-meeples-boardgame-list.onrender.com"
+    PUBLIC_BASE_URL or "https://mana-meeples-boardgame-list-opgf.onrender.com"
 )
 
 # HTTP client configuration

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 
     <!-- API Configuration -->
-    <meta name="api-base" content="https://mana-meeples-boardgame-list.onrender.com" />
+    <meta name="api-base" content="https://mana-meeples-boardgame-list-opgf.onrender.com" />
 
     <title>Mana & Meeples Library</title>
   </head>

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -40,7 +40,7 @@ function resolveApiBase() {
   if (typeof window !== "undefined" &&
       (window.location.hostname.includes('onrender.com') ||
        window.location.hostname.includes('manaandmeeples.co.nz'))) {
-    const productionUrl = "https://mana-meeples-boardgame-list.onrender.com";
+    const productionUrl = "https://mana-meeples-boardgame-list-opgf.onrender.com";
     console.warn('[API Config] VITE_API_BASE not set, using production fallback:', productionUrl);
     return productionUrl;
   }

--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,7 @@ services:
       - key: CORS_ORIGINS
         value: https://manaandmeeples.co.nz,https://www.manaandmeeples.co.nz,https://library.manaandmeeples.co.nz,https://mana-meeples-library-web.onrender.com
       - key: PUBLIC_BASE_URL
-        value: https://mana-meeples-boardgame-list.onrender.com
+        value: https://mana-meeples-boardgame-list-opgf.onrender.com
       - key: THUMBS_DIR
         value: /var/data/thumbs
       - key: CLOUDINARY_CLOUD_NAME
@@ -57,7 +57,7 @@ services:
     staticPublishPath: ./frontend/build
     envVars:
       - key: VITE_API_BASE
-        value: https://mana-meeples-boardgame-list.onrender.com
+        value: https://mana-meeples-boardgame-list-opgf.onrender.com
     routes:
       - type: rewrite
         source: /*


### PR DESCRIPTION
Updated all API base URLs from mana-meeples-boardgame-list.onrender.com to mana-meeples-boardgame-list-opgf.onrender.com to match the actual deployed service URL shown in Render logs.

This was causing CORS errors because the frontend was trying to access the old URL while the backend was deployed at the new URL with -opgf suffix.

Files updated:
- render.yaml: Updated PUBLIC_BASE_URL and VITE_API_BASE env vars
- frontend/index.html: Updated api-base meta tag
- frontend/src/config/api.js: Updated production fallback URL
- backend/config.py: Updated API_BASE fallback URL

This resolves the "No 'Access-Control-Allow-Origin' header" errors by ensuring the frontend requests go to the correct backend URL.