### PR TITLE
test: update API_BASE test to expect new Render URL

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -112,7 +112,7 @@ class TestAPIConfiguration:
             importlib.reload(config)
 
             assert config.PUBLIC_BASE_URL == ""
-            assert config.API_BASE == "https://mana-meeples-boardgame-list.onrender.com"
+            assert config.API_BASE == "https://mana-meeples-boardgame-list-opgf.onrender.com"
 
     def test_public_base_url_custom(self):
         """Test custom PUBLIC_BASE_URL"""


### PR DESCRIPTION
Updated test expectation to match the new backend URL with -opgf suffix.