### PR TITLE
fix: correct expansion filter to include all games except require-bas…

### DIFF
--- a/backend/services/game_service.py
+++ b/backend/services/game_service.py
@@ -103,13 +103,13 @@ class GameService:
             selectinload(Game.expansions)
         ).where(or_(Game.status == "OWNED", Game.status.is_(None)))
 
-        # Exclude require-base expansions from public view
-        # Only show base games and standalone expansions (expansion_type = 'both' or 'standalone')
-        # Note: Use isnot(True) to include both False and NULL values (for backward compatibility)
+        # Exclude only require-base expansions from public view
+        # Include: base games, standalone expansions, and expansions with no type set
+        # Only exclude games explicitly marked as is_expansion=True AND expansion_type='require-base'
         query = query.where(
-            or_(
-                Game.is_expansion.isnot(True),  # Base games (False or NULL)
-                Game.expansion_type.in_(["both", "standalone"]),  # Standalone expansions
+            ~and_(
+                Game.is_expansion == True,
+                Game.expansion_type == 'require-base'
             )
         )
 
@@ -222,9 +222,9 @@ class GameService:
         count_query = select(func.count(Game.id)).where(
             or_(Game.status == "OWNED", Game.status.is_(None))
         ).where(
-            or_(
-                Game.is_expansion.isnot(True),
-                Game.expansion_type.in_(["both", "standalone"]),
+            ~and_(
+                Game.is_expansion == True,
+                Game.expansion_type == 'require-base'
             )
         )
 


### PR DESCRIPTION
…e expansions

Problem:
- Previous filter excluded ANY expansion where expansion_type was NULL
- This incorrectly excluded ~12 games (232 actual vs 220 counted)
- Filter was: (is_expansion != True) OR (expansion_type IN ['both', 'standalone'])
- This excluded games where is_expansion=True AND expansion_type=NULL

Solution:
- Changed to only exclude games explicitly marked as require-base expansions
- New filter: NOT (is_expansion=True AND expansion_type='require-base')
- This includes:
  * All base games (is_expansion=False or NULL)
  * Standalone expansions (expansion_type='standalone' or 'both')
  * Expansions with no type set (expansion_type=NULL)
- Only excludes: require-base expansions

Impact:
- Count query now returns accurate total (232 instead of 220)
- All owned games are now visible in the public catalogue
- Infinite scroll can load all available games