### PR TITLE
fix: increase image-proxy rate limit to handle admin pages with many …

### DIFF
--- a/backend/api/routers/public.py
+++ b/backend/api/routers/public.py
@@ -285,7 +285,7 @@ async def get_games_by_designer(
 
 
 @router.get("/image-proxy")
-@limiter.limit("300/minute")  # Allow higher rate for pages with many images
+@limiter.limit("1000/minute")  # High limit for pages with many images (admin pages can have 100+ games)
 async def image_proxy(
     request: Request,
     url: str = Query(..., description="Image URL to proxy"),


### PR DESCRIPTION
…games

- Increase rate limit from 300 to 1000 requests/minute
- Admin pages can load 100+ games at once, each requiring an image
- Previous limit caused 429 errors when loading admin library page

Issue: All images failing to load on admin side due to rate limiting