### PR TITLE
Fix broken image loading system

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -243,12 +243,21 @@ async def _download_and_update_thumbnail(game_id: int, thumbnail_url: str):
         db.close()
 
 
-async def _reimport_single_game(game_id: int, bgg_id: int):
+async def _reimport_single_game(game_id: int, bgg_id: int, delay_seconds: float = 0):
     """
     Background task to re-import a single game with enhanced data.
     Uses consolidated GameService.update_game_from_bgg_data method.
+
+    Args:
+        game_id: Database ID of the game
+        bgg_id: BoardGameGeek ID
+        delay_seconds: Initial delay before processing (for rate limiting)
     """
     try:
+        # Add delay to avoid overwhelming BGG API
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+
         db = SessionLocal()
         game = db.get(Game, game_id)
         if not game:


### PR DESCRIPTION
…andling

This commit addresses three critical issues in the image loading system:

1. **BGG Rate Limiting**: Added staggered delays (2s between requests) to the re-import-all-games endpoint to prevent "429 Too Many Requests" errors. Now processes ~30 games/minute with accurate time estimates in response.

2. **Cloudinary Pre-generation 404s**: Disabled pre-generating Cloudinary URLs during game import, as URLs were cached before images were uploaded to Cloudinary. Now the image proxy handles upload on-demand (first request).

3. **BGG URL Format Mismatch**: Fixed URL transformation to handle BGG's new double-underscore format (__d/, __original/) in addition to legacy single- underscore format (_d., _original.). This prevents malformed URLs.

Changes:
- backend/main.py: Added delay_seconds parameter to _reimport_single_game()
- backend/api/routers/bulk.py: Staggered background task scheduling with delays
- backend/services/game_service.py: Disabled cloudinary_url pre-generation, fixed URL format regex to handle both __SIZE/ and _SIZE. patterns

Impact:
- Re-import now completes successfully without BGG rate limit errors
- Images load correctly on first request (no 404s from missing Cloudinary URLs)
- BGG URL transformations work with both old and new URL formats