### PR TITLE
fix: transform __original URLs and detect /img/ malformed patterns

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -188,6 +188,10 @@ export function generateSrcSet(url) {
     return null; // Only works for BGG images
   }
 
+  // IMPORTANT: Transform __original to __d BEFORE generating srcset
+  // BGG blocks __original downloads with 400 Bad Request
+  const baseUrl = getBGGImageVariant(url, 'detail');
+
   // Generate URLs for different sizes with Cloudinary transformations
   // The backend will handle uploading to Cloudinary and applying transformations
   const sizes = [
@@ -200,7 +204,7 @@ export function generateSrcSet(url) {
 
   return sizes
     .map(({ width, height }) => {
-      const proxyUrl = `${API_BASE}/api/public/image-proxy?url=${encodeURIComponent(url)}&width=${width}&height=${height}`;
+      const proxyUrl = `${API_BASE}/api/public/image-proxy?url=${encodeURIComponent(baseUrl)}&width=${width}&height=${height}`;
       return `${proxyUrl} ${width}w`;
     })
     .join(', ');


### PR DESCRIPTION
Critical fixes for image loading errors:

1. Frontend (config/api.js):
   - generateSrcSet() now transforms __original to __d before encoding
   - Prevents 400 Bad Request errors from BGG blocking __original

2. Backend (public.py):
   - Added safety check to transform __original to __d before download
   - Defense-in-depth: catches any __original URLs that slip through
   - Enhanced malformed URL detection to include /img/ and /0x0/ patterns
   - Now catches Star Wars-style malformed URLs with transformation params

Example malformed URL that's now handled:
https://cf.geekdo-images.com/HASH__original/img/JUNK=/0x0/filters:format(png)/pic123.png Cleaned to:
https://cf.geekdo-images.com/HASH__d/pic123.png

Impact:
- Fixes 400 Bad Request errors from BGG
- Handles malformed URLs with embedded transformation parameters
- Both frontend and backend now properly transform blocked URLs