### PR TITLE
fix: measure actual uncompressed image size instead of estimating

### DIFF
--- a/backend/services/cloudinary_service.py
+++ b/backend/services/cloudinary_service.py
@@ -125,13 +125,16 @@ class CloudinaryService:
                 original_format = image.format or 'JPEG'
                 logger.info(f"Opened image: {original_size}, format: {original_format}")
 
-                # Calculate uncompressed size (width × height × channels × bytes_per_channel)
-                channels = len(image.getbands())  # 3 for RGB, 4 for RGBA
-                uncompressed_size = original_size[0] * original_size[1] * channels * 1  # 1 byte per channel
+                # Get ACTUAL uncompressed size by saving as uncompressed PNG
+                # This matches what Cloudinary will see when processing the image
+                test_output = io.BytesIO()
+                # Save with no compression to get true uncompressed size
+                image.save(test_output, format='PNG', compress_level=0)
+                uncompressed_size = len(test_output.getvalue())
 
                 logger.info(
                     f"Image stats: {original_size[0]}x{original_size[1]}, "
-                    f"{channels} channels, {original_format} format, "
+                    f"mode: {image.mode}, {original_format} format, "
                     f"compressed: {image_size / (1024 * 1024):.2f}MB, "
                     f"uncompressed: {uncompressed_size / (1024 * 1024):.2f}MB"
                 )


### PR DESCRIPTION
Previous formula (width × height × channels) underestimated size:
- Estimated: 9.86MB
- Cloudinary actual: 11.2MB
- Difference: 1.34MB of PNG metadata/overhead

New approach:
- Save image as uncompressed PNG (compress_level=0)
- Measure actual bytes
- This matches what Cloudinary sees

For the failing image (pic5675728.png):
- 2736x3780, grayscale PNG
- Compressed download: 2.46MB
- Simple calc: 9.86MB (WRONG - resize didn't trigger)
- Actual uncompressed: ~11.2MB (NOW DETECTED)

This should finally trigger resize for all problematic images.