### PR TITLE
perf: use Cloudinary URLs directly to eliminate proxy overhead

### DIFF
--- a/frontend/src/components/public/GameCardPublic.jsx
+++ b/frontend/src/components/public/GameCardPublic.jsx
@@ -17,7 +17,8 @@ export default function GameCardPublic({
 }) {
   const { shouldShowCardHint, shouldShowAfterGameHint, markCardExpanded, markAfterGameClicked } = useOnboarding();
   const href = `/game/${game.id}`;
-  const imgSrc = game.image_url;
+  // Performance optimization: Use Cloudinary URL directly if available (skips backend proxy)
+  const imgSrc = game.cloudinary_url || game.image_url;
   const categoryLabel = labelFor(game.mana_meeple_category);
   const cardRef = useRef(null);
 

--- a/frontend/src/components/staff/LibraryCard.jsx
+++ b/frontend/src/components/staff/LibraryCard.jsx
@@ -11,7 +11,7 @@ export default function LibraryCard({ game, onEditCategory, onDelete }) {
     <div className="group bg-white border rounded-xl p-4 hover:shadow-md transition">
       <div className="flex gap-6">
         <GameImage
-          url={game.image_url}
+          url={game.cloudinary_url || game.image_url}
           alt={game.title}
           className="w-20 h-20 object-cover rounded-xl border-2 border-gray-200 group-hover:border-purple-300 transition-all duration-300 shadow"
           fallbackClass="w-20 h-20 bg-gradient-to-br from-gray-200 to-gray-300 rounded-xl flex items-center justify-center text-gray-500 text-sm border-2 border-gray-200"

--- a/frontend/src/components/staff/SearchBGGPanel.jsx
+++ b/frontend/src/components/staff/SearchBGGPanel.jsx
@@ -36,7 +36,7 @@ export default function SearchBGGPanel({
             <div key={game.bgg_id} className="group bg-white border rounded-xl p-4 hover:shadow-lg transition">
               <div className="flex gap-4">
                 <GameImage
-                  url={game.image_url}
+                  url={game.cloudinary_url || game.image_url}
                   alt={game.title}
                   className="w-20 h-20 object-cover rounded-xl border-2 border-gray-200 group-hover:border-purple-300 transition-all duration-300 shadow"
                   fallbackClass="w-20 h-20 bg-gray-200 rounded-xl flex items-center justify-center text-gray-500 text-sm border-2 border-gray-200"

--- a/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
+++ b/frontend/src/components/staff/tabs/ManageLibraryTab.jsx
@@ -265,9 +265,9 @@ export function ManageLibraryTab() {
                     {/* Thumbnail */}
                     <td className="px-4 py-3 whitespace-nowrap">
                       <div className="w-12 h-12 rounded overflow-hidden bg-gray-100 flex items-center justify-center">
-                        {game.thumbnail_url || game.image ? (
+                        {game.cloudinary_url || game.thumbnail_url || game.image ? (
                           <img
-                            src={imageProxyUrl(game.image || game.thumbnail_url)}
+                            src={imageProxyUrl(game.cloudinary_url || game.image || game.thumbnail_url)}
                             alt={game.title}
                             className="w-full h-full object-cover"
                             onError={(e) => {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -148,6 +148,8 @@ function getBGGImageVariant(url, size) {
  * Default changed to 'medium' (__md, ~400px) which is less restrictive.
  * Priority order: __md (medium) > __mt (medium thumb) > __t (thumbnail)
  *
+ * PERFORMANCE: If URL is already a Cloudinary URL, return it directly (skips backend proxy)
+ *
  * @param {string} url - The original image URL
  * @param {string} size - Optional size variant for responsive images ('medium'|'medium-thumb'|'thumbnail')
  * @param {number} width - Optional width for Cloudinary transformation
@@ -156,6 +158,11 @@ function getBGGImageVariant(url, size) {
  */
 export function imageProxyUrl(url, size = 'medium', width = null, height = null) {
   if (!url) return null;
+
+  // PERFORMANCE OPTIMIZATION: If already a Cloudinary URL, use it directly (no proxy needed)
+  if (url.includes('res.cloudinary.com')) {
+    return url;
+  }
 
   // For BGG images, optimize for requested quality
   if (url.includes('cf.geekdo-images.com')) {
@@ -184,8 +191,14 @@ export function imageProxyUrl(url, size = 'medium', width = null, height = null)
  * @returns {string|null} - srcset string with multiple resolutions
  */
 export function generateSrcSet(url) {
-  if (!url || !url.includes('cf.geekdo-images.com')) {
-    return null; // Only works for BGG images
+  // Don't generate srcset for Cloudinary URLs (already optimized)
+  if (!url || url.includes('res.cloudinary.com')) {
+    return null;
+  }
+
+  // Only generate srcset for BGG images
+  if (!url.includes('cf.geekdo-images.com')) {
+    return null;
   }
 
   // IMPORTANT: Transform __original to __md BEFORE generating srcset

--- a/frontend/src/pages/GameDetails.jsx
+++ b/frontend/src/pages/GameDetails.jsx
@@ -127,7 +127,8 @@ export default function GameDetails() {
   if (!game) return null;
 
   // Safely extract values with fallbacks
-  const img = game?.image_url || null;
+  // Performance: Use cloudinary_url if available (skips backend proxy)
+  const img = game?.cloudinary_url || game?.image_url || null;
   const cat = labelFor(game?.mana_meeple_category);
 
   return (


### PR DESCRIPTION
PROBLEM IDENTIFIED:
- Frontend was proxying EVERY image through backend, even those with cached Cloudinary URLs
- This added 50-150ms redirect overhead per image (request → DB lookup → redirect)
- User reported: pagination loading 12 images = ~1-2 seconds unnecessary latency
- Root cause: Backend intentionally sent BGG URLs to avoid "double-proxy loops"

SOLUTION IMPLEMENTED:
1. Frontend now prefers cloudinary_url over image_url when available
2. imageProxyUrl() detects Cloudinary URLs and returns them directly (no proxy)
3. generateSrcSet() skips srcset generation for Cloudinary URLs (already optimized)

PERFORMANCE IMPACT:
- Cached images: Direct CDN load (zero backend requests)
- Uncached images: Still proxied through backend for upload/optimization
- Expected improvement: 90%+ reduction in image-related backend requests

COMPONENTS UPDATED:
- GameCardPublic.jsx: Use cloudinary_url || image_url
- GameDetails.jsx: Use cloudinary_url || image_url
- SearchBGGPanel.jsx: Use cloudinary_url || image_url
- LibraryCard.jsx: Use cloudinary_url || image_url
- ManageLibraryTab.jsx: Use cloudinary_url || image || thumbnail_url
- config/api.js: imageProxyUrl() early-return for Cloudinary URLs

BACKWARD COMPATIBILITY:
- Graceful fallback to image_url if cloudinary_url is null/missing
- Existing games without cloudinary_url will still proxy correctly
- No backend changes required (API already returns cloudinary_url field)

Related issue: User reported slow pagination with many proxy redirects