### PR TITLE
fix: use debounced search value for URL updates to prevent flickering

### DIFF
--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -143,7 +143,7 @@ export default function PublicCatalogue() {
   // Update URL when filters change
   useEffect(() => {
     const params = new URLSearchParams();
-    if (q) params.set("q", q);
+    if (qDebounced) params.set("q", qDebounced);
     if (category !== "all") params.set("category", category);
     if (designer) params.set("designer", designer);
     if (nzDesigner) params.set("nz_designer", "true");
@@ -153,7 +153,7 @@ export default function PublicCatalogue() {
     if (sort !== "year_desc") params.set("sort", sort); // Changed default
 
     setSearchParams(params, { replace: true });
-  }, [q, category, designer, nzDesigner, players, complexityRange, recentlyAdded, sort, setSearchParams]);
+  }, [qDebounced, category, designer, nzDesigner, players, complexityRange, recentlyAdded, sort, setSearchParams]);
 
   // Fetch category counts
   useEffect(() => {


### PR DESCRIPTION
Fixes #358

## Problem
The search bar was flickering when typing, especially on mobile, because URL parameters were being updated on every keystroke instead of using the debounced search value.

## Solution
- Changed URL parameter update logic to use `qDebounced` instead of `q`
- This ensures URL updates wait for the 150ms debounce period, matching API call behavior
- Eliminates rapid URL changes that cause flickering, especially on mobile

## Testing
- Search input now updates URL only after 150ms delay
- No more flickering when typing in search box
- Maintains proper URL state for sharing/bookmarking

Generated with [Claude Code](https://claude.ai/code)