### PR TITLE
fix: resolve infinite scrolling pagination stopping issue

### DIFF
--- a/frontend/src/pages/PublicCatalogue.jsx
+++ b/frontend/src/pages/PublicCatalogue.jsx
@@ -215,7 +215,15 @@ export default function PublicCatalogue() {
   // Load more function - Memoized to ensure Intersection Observer has latest filter values
   const loadMore = useCallback(async () => {
     // Prevent duplicate loads with multiple safety checks
-    if (isLoadingMoreRef.current || allLoadedItems.length >= total) return;
+    if (isLoadingMoreRef.current || allLoadedItems.length >= total) {
+      // Debug logging to help identify issues
+      if (allLoadedItems.length >= total && total > 0) {
+        console.log(`✓ All items loaded: ${allLoadedItems.length} of ${total}`);
+      }
+      return;
+    }
+
+    console.log(`Loading more games: currently have ${allLoadedItems.length} of ${total}, requesting page ${page + 1}`);
 
     isLoadingMoreRef.current = true;
     setLoadingMore(true);
@@ -235,6 +243,12 @@ export default function PublicCatalogue() {
       if (recentlyAdded) params.recently_added = 30;
 
       const data = await getPublicGames(params);
+      console.log(`API returned ${data.items?.length || 0} items for page ${nextPage}, total: ${data.total}`);
+
+      // Update total count in case it changed (can happen with real-time updates)
+      if (data.total !== undefined && data.total !== total) {
+        setTotal(data.total);
+      }
 
       // Prevent adding duplicate items by checking IDs
       if (data.items && data.items.length > 0) {
@@ -250,11 +264,14 @@ export default function PublicCatalogue() {
 
           // Only update if we have new items
           if (newItems.length > 0) {
+            console.log(`✓ Added ${newItems.length} new items, total now: ${prev.length + newItems.length}`);
             return [...prev, ...newItems];
           }
           return prev;
         });
         setPage(nextPage);
+      } else {
+        console.log('No items returned from API, stopping pagination');
       }
 
       // REMOVED: Scroll restoration that was fighting with user scrolling
@@ -275,7 +292,7 @@ export default function PublicCatalogue() {
 
     // Use a ref to track when the observer last triggered to prevent rapid-fire calls
     let lastTriggerTime = 0;
-    const MIN_TRIGGER_INTERVAL = 1000; // FIXED: Increased to 1000ms to prevent freeze during loading
+    const MIN_TRIGGER_INTERVAL = 300; // FIXED: Reduced from 1000ms to 300ms for more responsive loading
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -283,11 +300,12 @@ export default function PublicCatalogue() {
         const now = Date.now();
 
         // CRITICAL: Only trigger if NOT currently loading AND enough time has passed
-        // This prevents the freeze/jump issue during scroll
+        // AND we haven't loaded all items yet
         if (
           entry.isIntersecting &&
           !isLoadingMoreRef.current &&
-          (now - lastTriggerTime) > MIN_TRIGGER_INTERVAL
+          (now - lastTriggerTime) > MIN_TRIGGER_INTERVAL &&
+          allLoadedItems.length < total // FIXED: Add explicit check for more items available
         ) {
           lastTriggerTime = now;
           loadMore();
@@ -295,8 +313,8 @@ export default function PublicCatalogue() {
       },
       {
         root: null, // viewport
-        rootMargin: '200px', // FIXED: Reduced to 200px to avoid too-early triggering
-        threshold: 0,
+        rootMargin: '100px', // FIXED: Reduced to 100px for better control
+        threshold: 0.1, // FIXED: Slight threshold to ensure intersection is meaningful
       }
     );
 
@@ -305,7 +323,7 @@ export default function PublicCatalogue() {
     return () => {
       observer.disconnect();
     };
-  }, [loadMore]); // Re-setup when loadMore changes (filter changes)
+  }, [loadMore, allLoadedItems.length, total]); // FIXED: Add dependencies for proper re-setup
 
   // Helper functions with accessibility announcements
   // Phase 1 Performance: Wrapped in useCallback to prevent unnecessary re-renders


### PR DESCRIPTION
Fixes issue where infinite scroll stopped at 208/220 games due to overly restrictive intersection observer configuration.

Key improvements:
- Reduced trigger interval from 1000ms to 300ms
- Optimized intersection observer settings
- Added explicit availability checks
- Fixed useEffect dependencies
- Added debug logging and total count sync

Closes #360

Generated with [Claude Code](https://claude.com/claude-code)