### PR TITLE
fix: resolve intersection observer test failure in infinite scroll

### DIFF
--- a/frontend/src/pages/__tests__/PublicCatalogue.test.jsx
+++ b/frontend/src/pages/__tests__/PublicCatalogue.test.jsx
@@ -207,10 +207,16 @@ describe('PublicCatalogue Page', () => {
       expect(screen.getByText('Game 1')).toBeInTheDocument();
     });
 
+    // Wait for the load more trigger element to be present
+    await waitFor(() => {
+      const loadMoreText = screen.queryByText(/scroll for more/i);
+      expect(loadMoreText).toBeInTheDocument();
+    });
+
     // Verify IntersectionObserver was created (wait for useEffect to complete)
     await waitFor(() => {
       expect(global.IntersectionObserver).toHaveBeenCalled();
-    });
+    }, { timeout: 2000 });
   });
 
   test('displays load more indicator when more pages available', async () => {
@@ -492,12 +498,21 @@ describe('PublicCatalogue Page', () => {
         </BrowserRouter>
       );
 
+      // Wait for the games to load first
       await waitFor(() => {
         expect(screen.getByText('Game 1')).toBeInTheDocument();
       });
 
-      // Verify IntersectionObserver was set up
-      expect(global.IntersectionObserver).toHaveBeenCalled();
+      // Wait for the load more trigger element to be present (needed for intersection observer)
+      await waitFor(() => {
+        const loadMoreText = screen.queryByText(/scroll for more/i);
+        expect(loadMoreText).toBeInTheDocument();
+      });
+
+      // Give the intersection observer useEffect time to run after the ref is attached
+      await waitFor(() => {
+        expect(global.IntersectionObserver).toHaveBeenCalled();
+      }, { timeout: 2000 });
     });
   });
 


### PR DESCRIPTION
Fixes the failing test for infinite scroll IntersectionObserver setup.

The test was failing because it expected IntersectionObserver to be called immediately, but needed to wait for proper DOM setup.

**Key improvements:**
- Added proper waitFor conditions to ensure games load and render
- Wait for load more trigger element to be present in DOM
- Ensure loadMoreTriggerRef is attached before testing
- Added sufficient timeout for IntersectionObserver useEffect to execute
- Applied fix to both intersection observer tests for consistency

Closes #360

Generated with [Claude Code](https://claude.com/claude-code)